### PR TITLE
Add Vue Router integration for payment dialogs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "pinia": "^3.0.3",
         "primeicons": "^7.0.0",
         "qrcode": "^1.5.4",
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@tsconfig/node22": "^22.0.2",
@@ -6146,6 +6147,27 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue-router/node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/vue-tsc": {
       "version": "3.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "pinia": "^3.0.3",
     "primeicons": "^7.0.0",
     "qrcode": "^1.5.4",
-    "vue": "^3.5.18"
+    "vue": "^3.5.18",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.2",

--- a/frontend/src/app/App.vue
+++ b/frontend/src/app/App.vue
@@ -1,11 +1,11 @@
-<script setup lang="ts">
-import Experience from '@/payments/components/Experience.vue'
-</script>
-
 <template>
   <div class="flex min-h-screen flex-col bg-brand-highlight/40">
     <main class="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
-      <Experience />
+      <RouterView />
     </main>
   </div>
 </template>
+
+<script setup lang="ts">
+import { RouterView } from 'vue-router'
+</script>

--- a/frontend/src/app/main.ts
+++ b/frontend/src/app/main.ts
@@ -3,6 +3,7 @@ import type { Pinia } from 'pinia'
 
 import App from '@/app/App.vue'
 import { createAppPinia } from '@/app/providers/createPinia'
+import { router } from '@/app/router'
 import { useI18nStore } from '@/localization/store'
 
 const initializeLocalization = async (pinia: Pinia) => {
@@ -15,8 +16,11 @@ export const bootstrapApp = async () => {
   const pinia = createAppPinia()
 
   app.use(pinia)
+  app.use(router)
 
   await initializeLocalization(pinia)
+
+  await router.isReady()
 
   app.mount('#app')
 }

--- a/frontend/src/app/router.ts
+++ b/frontend/src/app/router.ts
@@ -1,0 +1,20 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+import Experience from '@/payments/components/Experience.vue'
+
+export const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    {
+      path: '/',
+      name: 'home',
+      component: Experience,
+    },
+    {
+      path: '/:methodId',
+      name: 'method',
+      component: Experience,
+    },
+  ],
+  scrollBehavior: () => ({ top: 0 }),
+})

--- a/frontend/src/payments/components/kakao/KakaoExperience.vue
+++ b/frontend/src/payments/components/kakao/KakaoExperience.vue
@@ -11,6 +11,8 @@ const paymentInfoStore = usePaymentInfoStore()
 const notMobileDialogRef = ref<InstanceType<typeof IsNotMobileDialog> | null>(null)
 const notInstalledDialogRef = ref<InstanceType<typeof IsNotInstalledDialog> | null>(null)
 
+const emit = defineEmits<{ close: [] }>()
+
 const run = async (): Promise<boolean> => {
   const ready = await paymentInfoStore.ensureMethodInfo('kakao')
 
@@ -44,9 +46,13 @@ const run = async (): Promise<boolean> => {
 defineExpose({
   run,
 })
+
+const onDialogClose = () => {
+  emit('close')
+}
 </script>
 
 <template>
-  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="kakao" @close="onDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="kakao" @close="onDialogClose" />
 </template>

--- a/frontend/src/payments/components/toss/TossExperience.vue
+++ b/frontend/src/payments/components/toss/TossExperience.vue
@@ -11,6 +11,8 @@ import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 
 const paymentInfoStore = usePaymentInfoStore()
 
+const emit = defineEmits<{ close: [] }>()
+
 const isInstructionVisible = ref(false)
 const tossInstructionCountdown = ref(0)
 const tossDeepLinkUrl = ref<string | null>(null)
@@ -85,6 +87,7 @@ const run = async (): Promise<boolean> => {
 
 const onInstructionClose = () => {
   closeInstructionDialog()
+  emit('close')
 }
 
 const onInstructionLaunchNow = () => {
@@ -97,6 +100,14 @@ const onInstructionReopen = () => {
   }
 
   void runDeepLink(tossDeepLinkUrl.value)
+}
+
+const onNotMobileDialogClose = () => {
+  emit('close')
+}
+
+const onNotInstalledDialogClose = () => {
+  emit('close')
 }
 
 defineExpose({
@@ -113,6 +124,6 @@ defineExpose({
     @launch-now="onInstructionLaunchNow"
     @reopen="onInstructionReopen"
   />
-  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" />
-  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" />
+  <IsNotMobileDialog ref="notMobileDialogRef" method="toss" @close="onNotMobileDialogClose" />
+  <IsNotInstalledDialog ref="notInstalledDialogRef" method="toss" @close="onNotInstalledDialogClose" />
 </template>

--- a/frontend/src/payments/components/transfer/TransferExperience.vue
+++ b/frontend/src/payments/components/transfer/TransferExperience.vue
@@ -7,6 +7,8 @@ import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
 const paymentInfoStore = usePaymentInfoStore()
 const isDialogVisible = ref(false)
 
+const emit = defineEmits<{ close: [] }>()
+
 const transferAmount = computed(() => paymentInfoStore.transferInfo?.amount.krw ?? 0)
 const transferAccounts = computed(() => paymentInfoStore.transferInfo?.account ?? [])
 
@@ -27,6 +29,7 @@ const closeDialog = () => {
 
 const onClose = () => {
   closeDialog()
+  emit('close')
 }
 
 defineExpose({


### PR DESCRIPTION
## Summary
- add a Vue Router configuration and mount the app through a router view
- synchronize payment option selections with route changes and return to the root path when dialogs close
- emit close events from payment experience dialogs and add the vue-router dependency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e01c189bec832c8ef4def02e8bb8ab