### PR TITLE
Configure dialog routing for GitHub Pages

### DIFF
--- a/frontend/src/app/router/index.ts
+++ b/frontend/src/app/router/index.ts
@@ -2,6 +2,29 @@ import { createRouter, createWebHistory } from 'vue-router'
 
 import Experience from '@/payments/components/Experience.vue'
 
+const normalizeBaseUrl = (baseUrl?: string) => {
+  if (!baseUrl || baseUrl === './') {
+    return '/'
+  }
+
+  const referenceOrigin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+
+  try {
+    const parsed = new URL(baseUrl, referenceOrigin)
+    baseUrl = parsed.pathname
+  } catch {
+    // If the value cannot be parsed as a full URL we keep it as-is.
+  }
+
+  const trimmed = baseUrl.replace(/^\/+|\/+$/g, '')
+
+  if (!trimmed) {
+    return '/'
+  }
+
+  return `/${trimmed}/`
+}
+
 const routes = [
   {
     path: '/',
@@ -21,6 +44,6 @@ const routes = [
 
 export const createAppRouter = () =>
   createRouter({
-    history: createWebHistory(import.meta.env.BASE_URL),
+    history: createWebHistory(normalizeBaseUrl(import.meta.env.BASE_URL)),
     routes,
   })

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -200,12 +200,26 @@ watch(
   { immediate: true },
 )
 
-const onSelectMethod = (methodId: string) => {
+const onSelectMethod = async (methodId: string) => {
   paymentStore.selectMethod(methodId)
 
   const method = paymentStore.getMethodById(methodId)
 
-  if (!method || isCurrencySelectorOpen.value) {
+  if (!method) {
+    return
+  }
+
+  if (dialogRouteMethods.has(methodId)) {
+    if (currentRouteMethod.value !== methodId) {
+      await router.replace({ name: 'payment-method', params: { method: methodId } })
+      return
+    }
+
+    void handleRouteDialog()
+    return
+  }
+
+  if (isCurrencySelectorOpen.value) {
     return
   }
 


### PR DESCRIPTION
## Summary
- normalize the router base URL so history mode works when hosted on GitHub Pages
- route to payment-specific paths when dialog-driven options are selected and reuse the route watcher to reopen dialogs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e01ac7e250832c85f68e5b8d073c4f