### PR TITLE
Integrate Stripe payment element and backend support

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,3 @@
+stripe-keys.json
+node_modules
+.env

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,34 @@
+# Stripe payment backend (Node.js)
+
+This directory contains a lightweight Express server that issues Stripe Payment Intents for the card payment experience.
+
+## Getting started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Copy the example key file and provide your Stripe credentials:
+
+   ```bash
+   cp stripe-keys.example.json stripe-keys.json
+   ```
+
+   Update `stripe-keys.json` with your publishable (`public_key`) and secret (`secret_key`) keys.
+
+3. Start the server:
+
+   ```bash
+   npm run dev
+   ```
+
+   The server listens on `http://localhost:5174` by default and exposes:
+
+   - `GET /healthz` – health check endpoint.
+   - `POST /api/payment-intents` – creates a Payment Intent using `automatic_payment_methods` and returns the `clientSecret` together with the publishable key.
+
+## GitHub Pages fallback
+
+Because GitHub Pages cannot run the Node.js server, a mocked response is available at `../backend/response/test-payment-intent.json`. The frontend automatically falls back to this file when it cannot reach the live backend.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,887 @@
+{
+  "name": "roadshop-payments-backend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "roadshop-payments-backend",
+      "version": "0.1.0",
+      "dependencies": {
+        "cors": "^2.8.5",
+        "express": "^4.21.1",
+        "stripe": "^16.9.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.13.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
+      "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "roadshop-payments-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "node --watch src/server.mjs",
+    "start": "node src/server.mjs"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.21.1",
+    "stripe": "^16.9.0"
+  }
+}

--- a/backend/response/test-payment-intent.json
+++ b/backend/response/test-payment-intent.json
@@ -1,0 +1,6 @@
+{
+  "isMock": true,
+  "message": "Stripe backend is not active. This is a mock response used on GitHub Pages.",
+  "publishableKey": "pk_test_mocked_publishable_key",
+  "clientSecret": null
+}

--- a/backend/src/server.mjs
+++ b/backend/src/server.mjs
@@ -1,0 +1,113 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import url from 'node:url'
+
+import cors from 'cors'
+import express from 'express'
+import Stripe from 'stripe'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+const CONFIG_PATH = path.resolve(__dirname, '..', 'stripe-keys.json')
+
+const DEFAULT_PORT = Number.parseInt(process.env.PORT ?? '5174', 10)
+
+const DEFAULT_AMOUNT_BY_CURRENCY = {
+  KRW: 130000,
+  USD: 12000,
+  EUR: 11000,
+  CNY: 85000,
+  JPY: 150000,
+}
+
+const loadStripeKeys = async () => {
+  try {
+    const data = await fs.readFile(CONFIG_PATH, 'utf8')
+    const parsed = JSON.parse(data)
+
+    if (!parsed.public_key || !parsed.secret_key) {
+      throw new Error('Missing public_key or secret_key in stripe-keys.json')
+    }
+
+    return {
+      publicKey: parsed.public_key,
+      secretKey: parsed.secret_key,
+    }
+  } catch (error) {
+    const baseError =
+      error instanceof Error ? error.message : 'Unable to read Stripe configuration.'
+    throw new Error(`${baseError} Please create backend/stripe-keys.json based on stripe-keys.example.json.`)
+  }
+}
+
+const resolveAmount = (currency, requestedAmount) => {
+  if (typeof requestedAmount === 'number' && Number.isFinite(requestedAmount) && requestedAmount > 0) {
+    return Math.round(requestedAmount)
+  }
+
+  const normalized = currency?.toUpperCase()
+  const fallback = DEFAULT_AMOUNT_BY_CURRENCY[normalized] ?? 12000
+  return fallback
+}
+
+const buildApp = async () => {
+  const { publicKey, secretKey } = await loadStripeKeys()
+  const stripe = new Stripe(secretKey)
+
+  const app = express()
+  app.use(cors())
+  app.use(express.json())
+
+  app.get('/healthz', (_req, res) => {
+    res.json({ status: 'ok' })
+  })
+
+  app.post('/api/payment-intents', async (req, res) => {
+    const { currency, amount } = req.body ?? {}
+
+    if (!currency || typeof currency !== 'string') {
+      res.status(400).json({ message: 'currency is required' })
+      return
+    }
+
+    try {
+      const intent = await stripe.paymentIntents.create({
+        amount: resolveAmount(currency, amount),
+        currency: currency.toLowerCase(),
+        automatic_payment_methods: {
+          enabled: true,
+        },
+      })
+
+      res.json({
+        clientSecret: intent.client_secret,
+        publishableKey: publicKey,
+      })
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to create Stripe payment intent.'
+      res.status(500).json({ message })
+    }
+  })
+
+  return app
+}
+
+const start = async () => {
+  try {
+    const app = await buildApp()
+    const port = DEFAULT_PORT
+
+    app.listen(port, () => {
+      console.log(`Stripe backend listening on http://localhost:${port}`)
+    })
+  } catch (error) {
+    console.error(error)
+    process.exit(1)
+  }
+}
+
+if (import.meta.url === url.pathToFileURL(process.argv[1]).href) {
+  await start()
+}
+
+export { buildApp }

--- a/backend/stripe-keys.example.json
+++ b/backend/stripe-keys.example.json
@@ -1,0 +1,4 @@
+{
+  "public_key": "pk_test_your_publishable_key",
+  "secret_key": "sk_test_your_secret_key"
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@stripe/stripe-js": "^8.0.0",
         "pinia": "^3.0.3",
         "primeicons": "^7.0.0",
         "qrcode": "^1.5.4",
@@ -1676,6 +1677,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.0.0.tgz",
+      "integrity": "sha512-dLvD55KT1cBmrqzgYRgY42qNcw6zW4HS5oRZs0xRvHw9gBWig5yDnWNop/E+/t2JK+OZO30zsnupVBN2MqW2mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
       }
     },
     "node_modules/@tsconfig/node22": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@stripe/stripe-js": "^8.0.0",
     "pinia": "^3.0.3",
     "primeicons": "^7.0.0",
     "qrcode": "^1.5.4",

--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -38,6 +38,17 @@
       "title": "Choose a currency",
       "description": "Choose the currency to use for {method} payments."
     },
+    "cardPayment": {
+      "title": "Pay with card",
+      "description": "Complete your {currency} payment securely using Stripe.",
+      "loading": "Preparing the secure card form…",
+      "testModeNotice": "Use Stripe test cards such as 4242 4242 4242 4242 to simulate a payment.",
+      "mockNotice": "Stripe backend is not running. This mock response is shown for GitHub Pages.",
+      "missingCurrency": "Select a currency before continuing with a card payment.",
+      "submit": "Confirm payment",
+      "success": "Payment confirmed. Stripe may ask for additional authentication.",
+      "error": "We couldn't confirm your payment. Please try again."
+    },
     "tossInstruction": {
       "title": "Send with Toss",
       "description": "We've <strong class=\"text-brand-accent\">automatically copied</strong> the account details you need for Toss.",

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -38,6 +38,17 @@
       "title": "通貨を選択してください",
       "description": "{method} 決済に使用する通貨を選択してください。"
     },
+    "cardPayment": {
+      "title": "カードで支払う",
+      "description": "Stripe を利用して {currency} の支払いを安全に完了しましょう。",
+      "loading": "安全なカード入力フォームを準備しています…",
+      "testModeNotice": "テストでは 4242 4242 4242 4242 などの Stripe テストカードをご利用ください。",
+      "mockNotice": "Stripe バックエンドが起動していません。GitHub Pages ではモック応答を表示します。",
+      "missingCurrency": "カード決済を続ける前に通貨を選択してください。",
+      "submit": "支払いを確定",
+      "success": "支払いが確認されました。追加の認証が求められる場合があります。",
+      "error": "支払いを確定できませんでした。もう一度お試しください。"
+    },
     "tossInstruction": {
       "title": "Tossで送金",
       "description": "送金に必要な口座情報を<strong class=\"text-brand-accent\">自動でコピー</strong>しました。",

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -38,6 +38,17 @@
       "title": "통화를 선택하세요",
       "description": "{method} 결제에 사용할 통화를 선택하세요."
     },
+    "cardPayment": {
+      "title": "카드로 결제하기",
+      "description": "Stripe를 통해 안전하게 {currency} 결제를 진행하세요.",
+      "loading": "안전한 카드 결제 폼을 준비하고 있습니다…",
+      "testModeNotice": "4242 4242 4242 4242 등의 Stripe 테스트 카드를 사용해 결제를 연습할 수 있습니다.",
+      "mockNotice": "Stripe 백엔드가 실행 중이 아닙니다. GitHub Pages에서는 모의 응답이 표시됩니다.",
+      "missingCurrency": "카드 결제를 진행하려면 먼저 통화를 선택하세요.",
+      "submit": "결제 확인",
+      "success": "결제가 확인되었습니다. Stripe에서 추가 인증을 요청할 수 있습니다.",
+      "error": "결제를 확인하지 못했습니다. 다시 시도해 주세요."
+    },
     "tossInstruction": {
       "title": "토스로 송금하기",
       "description": "송금에 필요한 계좌 정보를 <strong class=\"text-brand-accent\">자동으로 복사</strong>해 두었어요.",

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -38,6 +38,17 @@
       "title": "选择货币",
       "description": "请选择用于 {method} 付款的货币。"
     },
+    "cardPayment": {
+      "title": "使用银行卡支付",
+      "description": "通过 Stripe 安全完成 {currency} 支付。",
+      "loading": "正在准备安全的银行卡表单…",
+      "testModeNotice": "请使用 Stripe 测试卡（例如 4242 4242 4242 4242）进行模拟支付。",
+      "mockNotice": "Stripe 后端未运行。在 GitHub Pages 上将显示模拟响应。",
+      "missingCurrency": "继续银行卡支付前，请先选择币种。",
+      "submit": "确认支付",
+      "success": "支付已确认，Stripe 可能会要求额外验证。",
+      "error": "无法确认支付，请稍后重试。"
+    },
     "tossInstruction": {
       "title": "使用 Toss 转账",
       "description": "已将转账所需的账户信息<strong class=\"text-brand-accent\">自动复制</strong>好了。",

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -8,6 +8,7 @@ import CurrencySelectorDialog from '@/payments/components/CurrencySelectorDialog
 import Section from '@/payments/components/Section.vue'
 import KakaoExperience from '@/payments/components/kakao/KakaoExperience.vue'
 import TossExperience from '@/payments/components/toss/TossExperience.vue'
+import CardExperience from '@/payments/components/card/CardExperience.vue'
 import TransferExperience from '@/payments/components/transfer/TransferExperience.vue'
 import { useLocalizedSections } from '@/payments/composables/useLocalizedSections'
 import { usePaymentStore } from '@/payments/stores/payment.store'
@@ -32,6 +33,7 @@ const { methods, selectedMethod, selectedCurrency, isCurrencySelectorOpen, isLoa
 
 const tossExperienceRef = ref<InstanceType<typeof TossExperience> | null>(null)
 const kakaoExperienceRef = ref<InstanceType<typeof KakaoExperience> | null>(null)
+const cardExperienceRef = ref<InstanceType<typeof CardExperience> | null>(null)
 const transferExperienceRef = ref<InstanceType<typeof TransferExperience> | null>(null)
 
 const categorizeMethod = (method: PaymentMethodWithCurrencies): PaymentCategory =>
@@ -92,6 +94,9 @@ const openMethodUrl = async (method: PaymentMethodWithCurrencies, currency: stri
 
 const runWorkflowForMethod = async (method: PaymentMethodWithCurrencies, currency: string | null) => {
   switch (method.id) {
+    case 'card':
+      await cardExperienceRef.value?.run(currency)
+      break
     case 'transfer':
       await transferExperienceRef.value?.run()
       break
@@ -224,6 +229,7 @@ const onExperienceClose = () => {
       @select="onCurrencySelect"
       @close="onCloseCurrencySelector"
     />
+    <CardExperience ref="cardExperienceRef" @close="onExperienceClose" />
     <TransferExperience ref="transferExperienceRef" @close="onExperienceClose" />
     <TossExperience ref="tossExperienceRef" @close="onExperienceClose" />
     <KakaoExperience ref="kakaoExperienceRef" @close="onExperienceClose" />

--- a/frontend/src/payments/components/card/CardExperience.vue
+++ b/frontend/src/payments/components/card/CardExperience.vue
@@ -1,0 +1,251 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import {
+  loadStripe,
+  type Stripe,
+  type StripeElements,
+  type StripePaymentElement,
+} from '@stripe/stripe-js'
+
+import DialogBase from '@/shared/components/DialogBase.vue'
+import LoadingOverlay from '@/shared/components/LoadingOverlay.vue'
+import { useI18nStore } from '@/localization/store'
+import {
+  createStripePaymentIntent,
+  type StripePaymentIntentPayload,
+} from '@/payments/services/stripePaymentService'
+
+type StripePaymentIntentResolved = StripePaymentIntentPayload & {
+  clientSecret: string
+  publishableKey: string
+}
+
+const emit = defineEmits<{ close: [] }>()
+
+const i18nStore = useI18nStore()
+
+const isVisible = ref(false)
+const isLoading = ref(false)
+const isSubmitting = ref(false)
+const isMockResponse = ref(false)
+const errorMessage = ref<string | null>(null)
+const statusMessage = ref<string | null>(null)
+const currentCurrency = ref<string | null>(null)
+const paymentElementContainer = ref<HTMLDivElement | null>(null)
+
+const stripeRef = ref<Stripe | null>(null)
+const elementsRef = ref<StripeElements | null>(null)
+let paymentElement: StripePaymentElement | null = null
+
+const dialogTitle = computed(() => i18nStore.t('dialogs.cardPayment.title'))
+const dialogDescription = computed(() =>
+  i18nStore.t('dialogs.cardPayment.description').replace(
+    '{currency}',
+    currentCurrency.value ?? '',
+  ),
+)
+const loadingMessage = computed(() => i18nStore.t('dialogs.cardPayment.loading'))
+const mockNotice = computed(() => i18nStore.t('dialogs.cardPayment.mockNotice'))
+const testModeNotice = computed(() => i18nStore.t('dialogs.cardPayment.testModeNotice'))
+const submitLabel = computed(() => i18nStore.t('dialogs.cardPayment.submit'))
+const successMessage = computed(() => i18nStore.t('dialogs.cardPayment.success'))
+const defaultErrorMessage = computed(() => i18nStore.t('dialogs.cardPayment.error'))
+const missingCurrencyMessage = computed(() => i18nStore.t('dialogs.cardPayment.missingCurrency'))
+
+const resetStripe = () => {
+  if (paymentElement) {
+    paymentElement.unmount()
+    paymentElement = null
+  }
+
+  elementsRef.value = null
+  stripeRef.value = null
+}
+
+const closeDialog = () => {
+  resetStripe()
+  isVisible.value = false
+  emit('close')
+}
+
+const mountPaymentElement = () => {
+  if (!paymentElementContainer.value || !elementsRef.value || paymentElement) {
+    return
+  }
+
+  paymentElement = elementsRef.value.create('payment', { layout: 'tabs' })
+  paymentElement.mount(paymentElementContainer.value)
+}
+
+watch([paymentElementContainer, elementsRef], () => {
+  if (isVisible.value) {
+    mountPaymentElement()
+  }
+})
+
+const initializeStripe = async (payload: StripePaymentIntentResolved): Promise<void> => {
+  const stripe = await loadStripe(payload.publishableKey)
+
+  if (!stripe) {
+    throw new Error('Failed to initialize Stripe with the provided publishable key.')
+  }
+
+  const elements = stripe.elements({
+    clientSecret: payload.clientSecret,
+    appearance: { theme: 'stripe' },
+  })
+
+  stripeRef.value = stripe
+  elementsRef.value = elements
+  mountPaymentElement()
+}
+
+const ensureStripePayload = (
+  payload: StripePaymentIntentPayload,
+): StripePaymentIntentResolved | null => {
+  if (!payload || !payload.clientSecret || !payload.publishableKey) {
+    return null
+  }
+
+  return {
+    clientSecret: payload.clientSecret,
+    publishableKey: payload.publishableKey,
+    isMock: payload.isMock ?? false,
+    message: payload.message,
+  }
+}
+
+const run = async (currency: string | null): Promise<boolean> => {
+  resetStripe()
+  isMockResponse.value = false
+  errorMessage.value = null
+  statusMessage.value = null
+
+  if (!currency) {
+    errorMessage.value = missingCurrencyMessage.value
+    return false
+  }
+
+  currentCurrency.value = currency
+  isVisible.value = true
+  isLoading.value = true
+
+  try {
+    const payload = await createStripePaymentIntent(currency)
+    const normalizedPayload = ensureStripePayload(payload)
+
+    if (payload.isMock || !normalizedPayload) {
+      isMockResponse.value = true
+      statusMessage.value = payload.message ?? mockNotice.value
+      return true
+    }
+
+    await initializeStripe(normalizedPayload)
+    statusMessage.value = normalizedPayload.message ?? testModeNotice.value
+    return true
+  } catch (error) {
+    const message = error instanceof Error ? error.message : defaultErrorMessage.value
+    errorMessage.value = message
+    return false
+  } finally {
+    isLoading.value = false
+  }
+}
+
+defineExpose({
+  run,
+})
+
+const submitPayment = async () => {
+  if (!stripeRef.value || !elementsRef.value) {
+    return
+  }
+
+  isSubmitting.value = true
+  errorMessage.value = null
+
+  const { error } = await stripeRef.value.confirmPayment({
+    elements: elementsRef.value,
+    confirmParams: {
+      return_url: window.location.href,
+    },
+    redirect: 'if_required',
+  })
+
+  if (error) {
+    errorMessage.value = error.message ?? defaultErrorMessage.value
+  } else {
+    statusMessage.value = successMessage.value
+  }
+
+  isSubmitting.value = false
+}
+
+onBeforeUnmount(() => {
+  resetStripe()
+})
+</script>
+
+<template>
+  <DialogBase
+    v-if="isVisible"
+    :title="dialogTitle"
+    :description="dialogDescription"
+    @close="closeDialog"
+  >
+    <div class="space-y-4">
+      <LoadingOverlay :visible="isLoading" :message="loadingMessage" />
+      <div v-if="errorMessage" class="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+        {{ errorMessage }}
+      </div>
+      <div v-else-if="statusMessage" class="rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+        {{ statusMessage }}
+      </div>
+      <form v-if="!isLoading && !isMockResponse" class="space-y-4" @submit.prevent="submitPayment">
+        <div ref="paymentElementContainer" class="rounded-xl border border-slate-200 p-4"></div>
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+          <button
+            type="button"
+            class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-100"
+            @click="closeDialog"
+          >
+            {{ i18nStore.t('dialogs.close') }}
+          </button>
+          <button
+            type="submit"
+            class="rounded-xl bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 disabled:opacity-60"
+            :disabled="isSubmitting"
+          >
+            <span v-if="isSubmitting" class="flex items-center gap-2">
+              <span class="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white"></span>
+              {{ submitLabel }}
+            </span>
+            <span v-else>{{ submitLabel }}</span>
+          </button>
+        </div>
+      </form>
+      <div v-else-if="isMockResponse" class="flex flex-col gap-3">
+        <p class="text-sm text-slate-600">{{ statusMessage ?? mockNotice }}</p>
+        <button
+          type="button"
+          class="self-end rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-100"
+          @click="closeDialog"
+        >
+          {{ i18nStore.t('dialogs.close') }}
+        </button>
+      </div>
+    </div>
+  </DialogBase>
+</template>
+
+<style scoped>
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.animate-spin {
+  animation: spin 0.8s linear infinite;
+}
+</style>

--- a/frontend/src/payments/services/paymentInfoService.ts
+++ b/frontend/src/payments/services/paymentInfoService.ts
@@ -47,15 +47,16 @@ const DEFAULT_API_BASE_URL =
 const normalizeBaseUrl = (value: string): string => value.replace(/\/+$/, '')
 const normalizePath = (value: string): string => value.replace(/^\/+/, '')
 
-const getApiBaseUrl = (): string => {
+export const getPaymentsApiBaseUrl = (): string => {
   const envUrl = import.meta.env?.VITE_PAYMENTS_API_BASE_URL as string | undefined
   return normalizeBaseUrl(envUrl && envUrl.length ? envUrl : DEFAULT_API_BASE_URL)
 }
 
-const buildApiUrl = (path: string): string => `${getApiBaseUrl()}/${normalizePath(path)}`
+export const buildPaymentsApiUrl = (path: string): string =>
+  `${getPaymentsApiBaseUrl()}/${normalizePath(path)}`
 
 const requestJson = async <T>(path: string): Promise<T> => {
-  const response = await fetch(buildApiUrl(path))
+  const response = await fetch(buildPaymentsApiUrl(path))
 
   if (!response.ok) {
     throw new Error(`Failed to load ${path}: ${response.status}`)

--- a/frontend/src/payments/services/stripePaymentService.ts
+++ b/frontend/src/payments/services/stripePaymentService.ts
@@ -1,0 +1,72 @@
+import { buildPaymentsApiUrl } from '@/payments/services/paymentInfoService'
+
+export type StripePaymentIntentPayload = {
+  clientSecret: string | null
+  publishableKey: string | null
+  isMock?: boolean
+  message?: string
+}
+
+const DEFAULT_API_ENDPOINT = '/api/payment-intents'
+const DEFAULT_TEST_RESPONSE_PATH = 'test-payment-intent.json'
+
+const resolveApiEndpoint = (): string => {
+  const envEndpoint = import.meta.env?.VITE_STRIPE_PAYMENT_INTENT_URL as string | undefined
+  if (envEndpoint && envEndpoint.length > 0) {
+    return envEndpoint
+  }
+
+  return DEFAULT_API_ENDPOINT
+}
+
+const resolveFallbackUrl = (): string => {
+  const envFallback = import.meta.env?.VITE_STRIPE_PAYMENT_INTENT_FALLBACK_URL as string | undefined
+  if (envFallback && envFallback.length > 0) {
+    return envFallback
+  }
+
+  return buildPaymentsApiUrl(DEFAULT_TEST_RESPONSE_PATH)
+}
+
+const parseJson = async (response: Response): Promise<StripePaymentIntentPayload> => {
+  const data = (await response.json()) as StripePaymentIntentPayload
+  return {
+    clientSecret: data.clientSecret ?? null,
+    publishableKey: data.publishableKey ?? null,
+    isMock: data.isMock ?? false,
+    message: data.message,
+  }
+}
+
+export const createStripePaymentIntent = async (
+  currency: string,
+  amount?: number,
+): Promise<StripePaymentIntentPayload> => {
+  const endpoint = resolveApiEndpoint()
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ currency, amount }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Stripe backend responded with ${response.status}`)
+    }
+
+    return await parseJson(response)
+  } catch (error) {
+    console.warn('Falling back to mock Stripe response:', error)
+    const fallbackResponse = await fetch(resolveFallbackUrl())
+
+    if (!fallbackResponse.ok) {
+      throw new Error(`Failed to load Stripe fallback response: ${fallbackResponse.status}`)
+    }
+
+    return await parseJson(fallbackResponse)
+  }
+}
+


### PR DESCRIPTION
## Summary
- add an Express-based Stripe backend with configurable API keys and mock GitHub Pages response
- wire the card payment flow to Stripe's Payment Element with localization updates and fallback handling
- expose shared API URL helpers and include the Stripe JS client dependency

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e0b207e42c832cb7c9c71ee656b481