### PR TITLE
Add Stripe card payment element integration

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+stripe-keys.json
+node_modules

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "payments-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
+  "scripts": {
+    "dev": "node --watch server.js",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.21.2",
+    "stripe": "^16.11.0"
+  }
+}

--- a/backend/response/method-card.json
+++ b/backend/response/method-card.json
@@ -1,13 +1,16 @@
 {
   "id": "card",
-  "type": "url",
+  "type": "stripe",
   "payload": {
-    "url": {
-      "KRW": "https://buy.stripe.com/eVq28qh1xh0688u6Xw18c00",
-      "USD": "https://buy.stripe.com/5kQbJ1aF9fqvh2MaiEgIo01",
-      "EUR": "https://buy.stripe.com/5kQbJ1aF9fqvh2MaiEgIo01",
-      "CNY": "https://buy.stripe.com/5kQbJ1aF9fqvh2MaiEgIo01",
-      "JPY": "https://buy.stripe.com/5kQbJ1aF9fqvh2MaiEgIo01"
+    "publishableKey": "pk_test_PLACEHOLDER",
+    "clientSecret": "pi_test_placeholder_secret_PLACEHOLDER",
+    "returnUrl": "https://eedocelsius.github.io/checkout/complete",
+    "appearance": {
+      "theme": "flat",
+      "variables": {
+        "colorPrimary": "#4338CA",
+        "borderRadius": "12px"
+      }
     }
   }
 }

--- a/backend/response/test-create-payment-intent.json
+++ b/backend/response/test-create-payment-intent.json
@@ -1,0 +1,7 @@
+{
+  "amount": 2000,
+  "currency": "usd",
+  "clientSecret": "pi_test_placeholder_secret_PLACEHOLDER",
+  "publishableKey": "pk_test_PLACEHOLDER",
+  "description": "Example response for POST /api/payments/create-intent"
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,94 @@
+import fs from 'node:fs/promises'
+import process from 'node:process'
+
+import cors from 'cors'
+import express from 'express'
+import Stripe from 'stripe'
+
+const app = express()
+app.use(cors())
+app.use(express.json())
+
+const readStripeKeys = async () => {
+  try {
+    const filePath = process.env.STRIPE_KEYS_PATH
+      ? new URL(process.env.STRIPE_KEYS_PATH, `file://${process.cwd()}/`)
+      : new URL('./stripe-keys.json', import.meta.url)
+
+    const raw = await fs.readFile(filePath, 'utf8')
+    return JSON.parse(raw)
+  } catch (error) {
+    if ((error ?? null) && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      console.warn('[stripe] stripe-keys.json not found; falling back to environment variables.')
+    } else {
+      console.warn('[stripe] Failed to read stripe-keys.json:', error)
+    }
+
+    return null
+  }
+}
+
+const keyFile = await readStripeKeys()
+
+const publishableKey = process.env.STRIPE_PUBLISHABLE_KEY ?? keyFile?.public_key ?? ''
+const secretKey = process.env.STRIPE_SECRET_KEY ?? keyFile?.secret_key ?? ''
+
+let stripe = null
+
+if (secretKey) {
+  stripe = new Stripe(secretKey, {
+    apiVersion: '2024-11-20',
+  })
+} else {
+  console.warn('[stripe] STRIPE_SECRET_KEY is not configured. Payment intent creation will be disabled.')
+}
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' })
+})
+
+app.post('/api/payments/create-intent', async (req, res) => {
+  if (!stripe) {
+    res.status(500).json({ error: 'Stripe secret key is not configured.' })
+    return
+  }
+
+  const { amount, currency, customerEmail, metadata } = req.body ?? {}
+
+  if (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0) {
+    res.status(400).json({ error: 'The "amount" field must be a positive number.' })
+    return
+  }
+
+  if (!currency || typeof currency !== 'string') {
+    res.status(400).json({ error: 'The "currency" field is required.' })
+    return
+  }
+
+  try {
+    const intent = await stripe.paymentIntents.create({
+      amount: Math.round(amount),
+      currency: currency.toLowerCase(),
+      receipt_email: typeof customerEmail === 'string' && customerEmail.length ? customerEmail : undefined,
+      metadata: typeof metadata === 'object' && metadata !== null ? metadata : undefined,
+      automatic_payment_methods: {
+        enabled: true,
+      },
+    })
+
+    res.json({
+      clientSecret: intent.client_secret,
+      publishableKey,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown Stripe error'
+    console.error('[stripe] Failed to create payment intent:', message)
+    res.status(500).json({ error: message })
+  }
+})
+
+const port = Number.parseInt(process.env.PORT ?? '8787', 10)
+
+app.listen(port, () => {
+  console.log(`Stripe backend listening on http://localhost:${port}`)
+})

--- a/backend/stripe-keys.example.json
+++ b/backend/stripe-keys.example.json
@@ -1,0 +1,4 @@
+{
+  "public_key": "pk_test_PLACEHOLDER",
+  "secret_key": "sk_test_PLACEHOLDER"
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@stripe/stripe-js": "^4.10.0",
         "pinia": "^3.0.3",
         "primeicons": "^7.0.0",
         "qrcode": "^1.5.4",
@@ -1676,6 +1677,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-4.10.0.tgz",
+      "integrity": "sha512-KrMOL+sH69htCIXCaZ4JluJ35bchuCCznyPyrbN8JXSGQfwBI1SuIEMZNwvy8L8ykj29t6sa5BAAiL7fNoLZ8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
       }
     },
     "node_modules/@tsconfig/node22": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@stripe/stripe-js": "^4.10.0",
     "pinia": "^3.0.3",
     "primeicons": "^7.0.0",
     "qrcode": "^1.5.4",

--- a/frontend/src/localization/messages/en.json
+++ b/frontend/src/localization/messages/en.json
@@ -43,6 +43,19 @@
       "description": "We've <strong class=\"text-brand-accent\">automatically copied</strong> the account details you need for Toss.",
       "launchCta": "Go to Toss",
       "reopen": "Reopen Toss"
+    },
+    "stripeCard": {
+      "title": "Pay with card",
+      "description": "Enter your card details below to complete the payment securely with Stripe.",
+      "testNotice": "This is a demo environment. Use the Stripe test card <strong>4242 4242 4242 4242</strong>, any future expiry date, and any CVC.",
+      "setupHint": "Update the backend or local test response with a valid Stripe publishable key and client secret to load the card form.",
+      "submit": "Confirm payment",
+      "processing": "Processing…",
+      "success": "Payment confirmed! This demo will not charge your card.",
+      "errors": {
+        "load": "We couldn't load the card form. Please try again later.",
+        "generic": "Something went wrong while confirming the payment. Please try again."
+      }
     }
   },
   "status": {

--- a/frontend/src/localization/messages/ja.json
+++ b/frontend/src/localization/messages/ja.json
@@ -43,6 +43,19 @@
       "description": "送金に必要な口座情報を<strong class=\"text-brand-accent\">自動でコピー</strong>しました。",
       "launchCta": "Tossへ移動",
       "reopen": "Tossをもう一度開く"
+    },
+    "stripeCard": {
+      "title": "カードで支払う",
+      "description": "Stripeを利用して安全に支払いを完了するため、カード情報を入力してください。",
+      "testNotice": "こちらはデモ環境です。Stripeテストカード <strong>4242 4242 4242 4242</strong>、未来の日付の有効期限、お好みのCVCをご利用ください。",
+      "setupHint": "バックエンドまたはテスト用レスポンスに有効なStripe公開キーとクライアントシークレットを設定すると、カードフォームが表示されます。",
+      "submit": "支払いを確定する",
+      "processing": "処理中…",
+      "success": "支払いが確認されました！このデモでは実際に課金されません。",
+      "errors": {
+        "load": "カードフォームを読み込めませんでした。時間をおいて再度お試しください。",
+        "generic": "支払いの確定中に問題が発生しました。もう一度お試しください。"
+      }
     }
   },
   "status": {

--- a/frontend/src/localization/messages/ko.json
+++ b/frontend/src/localization/messages/ko.json
@@ -43,6 +43,19 @@
       "description": "송금에 필요한 계좌 정보를 <strong class=\"text-brand-accent\">자동으로 복사</strong>해 두었어요.",
       "launchCta": "토스로 이동하기",
       "reopen": "토스 다시열기"
+    },
+    "stripeCard": {
+      "title": "카드로 결제하기",
+      "description": "아래에 카드 정보를 입력하고 Stripe를 통해 안전하게 결제하세요.",
+      "testNotice": "이 환경은 데모입니다. Stripe 테스트 카드 <strong>4242 4242 4242 4242</strong>와 유효한 미래 만료일, 임의의 CVC를 사용해 보세요.",
+      "setupHint": "백엔드나 테스트 응답에서 Stripe 공개 키와 클라이언트 시크릿을 올바르게 설정하면 카드 폼이 표시됩니다.",
+      "submit": "결제 확인",
+      "processing": "처리 중…",
+      "success": "결제가 확인되었습니다! 이 데모에서는 실제로 결제가 이루어지지 않습니다.",
+      "errors": {
+        "load": "카드 입력 폼을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
+        "generic": "결제 확인 중 문제가 발생했습니다. 다시 시도해 주세요."
+      }
     }
   },
   "status": {

--- a/frontend/src/localization/messages/zh.json
+++ b/frontend/src/localization/messages/zh.json
@@ -43,6 +43,19 @@
       "description": "已将转账所需的账户信息<strong class=\"text-brand-accent\">自动复制</strong>好了。",
       "launchCta": "前往 Toss",
       "reopen": "重新打开 Toss"
+    },
+    "stripeCard": {
+      "title": "使用银行卡支付",
+      "description": "请输入银行卡信息，通过 Stripe 安全地完成支付。",
+      "testNotice": "当前为演示环境。请使用 Stripe 测试卡 <strong>4242 4242 4242 4242</strong>，任意未来有效期和任意 CVC。",
+      "setupHint": "请在后端或测试响应中配置有效的 Stripe 公钥和客户端密钥，以加载银行卡表单。",
+      "submit": "确认支付",
+      "processing": "处理中…",
+      "success": "支付已确认！此演示不会产生真实扣款。",
+      "errors": {
+        "load": "未能加载银行卡表单，请稍后重试。",
+        "generic": "确认支付时出现问题，请重试。"
+      }
     }
   },
   "status": {

--- a/frontend/src/payments/components/Experience.vue
+++ b/frontend/src/payments/components/Experience.vue
@@ -6,6 +6,7 @@ import { useRoute, useRouter } from 'vue-router'
 import LoadingOverlay from '@/shared/components/LoadingOverlay.vue'
 import CurrencySelectorDialog from '@/payments/components/CurrencySelectorDialog.vue'
 import Section from '@/payments/components/Section.vue'
+import StripeCardExperience from '@/payments/components/card/StripeCardExperience.vue'
 import KakaoExperience from '@/payments/components/kakao/KakaoExperience.vue'
 import TossExperience from '@/payments/components/toss/TossExperience.vue'
 import TransferExperience from '@/payments/components/transfer/TransferExperience.vue'
@@ -30,6 +31,7 @@ const route = useRoute()
 const { methods, selectedMethod, selectedCurrency, isCurrencySelectorOpen, isLoading: areMethodsLoading, error: methodsError } =
   storeToRefs(paymentStore)
 
+const cardExperienceRef = ref<InstanceType<typeof StripeCardExperience> | null>(null)
 const tossExperienceRef = ref<InstanceType<typeof TossExperience> | null>(null)
 const kakaoExperienceRef = ref<InstanceType<typeof KakaoExperience> | null>(null)
 const transferExperienceRef = ref<InstanceType<typeof TransferExperience> | null>(null)
@@ -94,6 +96,9 @@ const runWorkflowForMethod = async (method: PaymentMethodWithCurrencies, currenc
   switch (method.id) {
     case 'transfer':
       await transferExperienceRef.value?.run()
+      break
+    case 'card':
+      await cardExperienceRef.value?.run()
       break
     case 'toss':
       await tossExperienceRef.value?.run()
@@ -225,6 +230,7 @@ const onExperienceClose = () => {
       @close="onCloseCurrencySelector"
     />
     <TransferExperience ref="transferExperienceRef" @close="onExperienceClose" />
+    <StripeCardExperience ref="cardExperienceRef" @close="onExperienceClose" />
     <TossExperience ref="tossExperienceRef" @close="onExperienceClose" />
     <KakaoExperience ref="kakaoExperienceRef" @close="onExperienceClose" />
     <LoadingOverlay

--- a/frontend/src/payments/components/card/StripeCardExperience.vue
+++ b/frontend/src/payments/components/card/StripeCardExperience.vue
@@ -1,0 +1,242 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { loadStripe, type Stripe, type StripeElements, type StripePaymentElement } from '@stripe/stripe-js'
+
+import DialogCloseFull from '@/shared/components/DialogCloseFull.vue'
+import { usePaymentInfoStore } from '@/payments/stores/paymentInfo.store'
+import { useI18nStore } from '@/localization/store'
+
+const emit = defineEmits<{ close: [] }>()
+
+const paymentInfoStore = usePaymentInfoStore()
+const i18nStore = useI18nStore()
+
+const isVisible = ref(false)
+const isProcessing = ref(false)
+const submissionError = ref<string | null>(null)
+const submissionSuccess = ref<string | null>(null)
+const formError = ref<string | null>(null)
+
+const stripeInstance = ref<Stripe | null>(null)
+const elements = ref<StripeElements | null>(null)
+const paymentElement = ref<StripePaymentElement | null>(null)
+const elementContainer = ref<HTMLDivElement | null>(null)
+
+const methodError = computed(() => paymentInfoStore.errors.card ?? null)
+const isLoading = computed(() => paymentInfoStore.isMethodLoading('card'))
+const stripeInfo = computed(() => paymentInfoStore.stripeCardInfo)
+
+const hasDemoKeys = computed(() => {
+  const info = stripeInfo.value
+  if (!info) {
+    return true
+  }
+
+  const normalizedPublishable = info.publishableKey.trim().toUpperCase()
+  const normalizedSecret = info.clientSecret.trim().toUpperCase()
+
+  return (
+    !normalizedPublishable.length ||
+    !normalizedSecret.length ||
+    normalizedPublishable.includes('PLACEHOLDER') ||
+    normalizedSecret.includes('PLACEHOLDER')
+  )
+})
+
+const destroyElement = () => {
+  if (paymentElement.value) {
+    paymentElement.value.unmount()
+    paymentElement.value = null
+  }
+
+  elements.value = null
+}
+
+const initializeElement = async () => {
+  formError.value = null
+  submissionError.value = null
+  submissionSuccess.value = null
+
+  if (hasDemoKeys.value) {
+    return
+  }
+
+  const info = stripeInfo.value
+  const container = elementContainer.value
+
+  if (!info || !container) {
+    return
+  }
+
+  destroyElement()
+
+  try {
+    stripeInstance.value = await loadStripe(info.publishableKey)
+
+    if (!stripeInstance.value) {
+      formError.value = i18nStore.t('dialogs.stripeCard.errors.load')
+      return
+    }
+
+    elements.value = stripeInstance.value.elements({
+      clientSecret: info.clientSecret,
+      appearance: (info.appearance as Record<string, unknown> | undefined) ?? { theme: 'stripe' },
+    })
+
+    paymentElement.value = elements.value.create('payment')
+    paymentElement.value.mount(container)
+  } catch (error) {
+    formError.value =
+      error instanceof Error ? error.message : i18nStore.t('dialogs.stripeCard.errors.load')
+  }
+}
+
+const confirmPayment = async () => {
+  const info = stripeInfo.value
+
+  if (!stripeInstance.value || !elements.value || !info) {
+    return
+  }
+
+  submissionError.value = null
+  submissionSuccess.value = null
+  isProcessing.value = true
+
+  try {
+    const result = await stripeInstance.value.confirmPayment({
+      elements: elements.value,
+      confirmParams: {
+        return_url: info.returnUrl ?? window.location.href,
+      },
+      redirect: 'if_required',
+    })
+
+    if (result.error) {
+      submissionError.value = result.error.message ?? i18nStore.t('dialogs.stripeCard.errors.generic')
+      return
+    }
+
+    submissionSuccess.value = i18nStore.t('dialogs.stripeCard.success')
+  } catch (error) {
+    submissionError.value =
+      error instanceof Error ? error.message : i18nStore.t('dialogs.stripeCard.errors.generic')
+  } finally {
+    isProcessing.value = false
+  }
+}
+
+const closeDialog = () => {
+  isVisible.value = false
+  destroyElement()
+  emit('close')
+}
+
+const run = async (): Promise<boolean> => {
+  submissionError.value = null
+  submissionSuccess.value = null
+  formError.value = null
+  isProcessing.value = false
+
+  isVisible.value = true
+  await nextTick()
+
+  const ready = await paymentInfoStore.ensureMethodInfo('card')
+
+  if (ready) {
+    await nextTick()
+    await initializeElement()
+  }
+
+  return ready
+}
+
+watch(
+  () => stripeInfo.value?.clientSecret,
+  async () => {
+    if (!isVisible.value) {
+      return
+    }
+
+    await nextTick()
+    await initializeElement()
+  },
+)
+
+onBeforeUnmount(() => {
+  destroyElement()
+})
+
+defineExpose({
+  run,
+})
+</script>
+
+<template>
+  <DialogCloseFull
+    v-if="isVisible"
+    :title="i18nStore.t('dialogs.stripeCard.title')"
+    :description="i18nStore.t('dialogs.stripeCard.description')"
+    @close="closeDialog"
+  >
+    <div class="space-y-4">
+      <p class="rounded-xl bg-brand-highlight/60 px-4 py-3 text-sm text-brand-primary/80" v-html="i18nStore.t('dialogs.stripeCard.testNotice')"></p>
+
+      <div
+        v-if="methodError"
+        class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      >
+        {{ methodError }}
+      </div>
+
+      <div
+        v-else-if="isLoading"
+        class="flex items-center justify-center rounded-xl border border-dashed border-brand-primary/30 px-4 py-12 text-sm text-brand-primary/70"
+      >
+        {{ i18nStore.t('status.loading.methods') }}
+      </div>
+
+      <div
+        v-else-if="hasDemoKeys"
+        class="rounded-xl border border-brand-primary/20 bg-brand-highlight/40 px-4 py-3 text-sm text-brand-primary/80"
+      >
+        {{ i18nStore.t('dialogs.stripeCard.setupHint') }}
+      </div>
+
+      <div v-else class="space-y-4">
+        <div
+          class="rounded-xl border border-slate-200 bg-white px-4 py-5 shadow-inner"
+        >
+          <div ref="elementContainer"></div>
+        </div>
+
+        <div v-if="formError" class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {{ formError }}
+        </div>
+
+        <button
+          type="button"
+          class="w-full rounded-xl bg-brand-primary px-4 py-3 text-sm font-semibold text-white transition hover:bg-brand-primary/90 disabled:cursor-not-allowed disabled:bg-brand-primary/50"
+          :disabled="isProcessing"
+          @click="confirmPayment"
+        >
+          <span v-if="isProcessing">{{ i18nStore.t('dialogs.stripeCard.processing') }}</span>
+          <span v-else>{{ i18nStore.t('dialogs.stripeCard.submit') }}</span>
+        </button>
+
+        <p v-if="submissionError" class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {{ submissionError }}
+        </p>
+
+        <p v-if="submissionSuccess" class="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+          {{ submissionSuccess }}
+        </p>
+      </div>
+    </div>
+  </DialogCloseFull>
+</template>
+
+<style scoped>
+button {
+  transition: background-color 0.2s ease;
+}
+</style>

--- a/frontend/src/payments/services/paymentInfoService.ts
+++ b/frontend/src/payments/services/paymentInfoService.ts
@@ -1,5 +1,12 @@
 import type { DeepLinkProvider } from '@/payments/types'
 
+export type StripePaymentInfo = {
+  publishableKey: string
+  clientSecret: string
+  returnUrl?: string
+  appearance?: Record<string, unknown>
+}
+
 export type TransferAccount = {
   bank: string
   number: string
@@ -40,9 +47,10 @@ export type PaymentMethodDetail =
   | { type: 'toss'; data: TossPaymentInfo }
   | { type: 'kakao'; data: KakaoPaymentInfo }
   | { type: 'url'; data: MethodUrlInfo }
+  | { type: 'stripe'; data: StripePaymentInfo }
 
 const DEFAULT_API_BASE_URL =
-  'https://raw.githubusercontent.com/EedoCelsius/roadshop/refs/heads/main/backend/response'
+  'https://raw.githubusercontent.com/EedoCelsius/eedocelsius.github.io/refs/heads/main/backend/response'
 
 const normalizeBaseUrl = (value: string): string => value.replace(/\/+$/, '')
 const normalizePath = (value: string): string => value.replace(/^\/+/, '')
@@ -73,6 +81,7 @@ type PaymentMethodDetailResponse =
   | { id: string; type: 'toss'; payload: TossPaymentInfo }
   | { id: string; type: 'kakao'; payload: KakaoPaymentInfo }
   | { id: string; type: 'url'; payload: MethodUrlInfo }
+  | { id: string; type: 'stripe'; payload: StripePaymentInfo }
 
 export const fetchAvailablePaymentMethods = async (): Promise<AvailablePaymentMethod[]> => {
   const data = await requestJson<AvailableMethodResponse>('payment-methods.json')
@@ -89,6 +98,8 @@ const normalizeDetail = (detail: PaymentMethodDetailResponse): PaymentMethodDeta
       return { type: 'kakao', data: detail.payload }
     case 'url':
       return { type: 'url', data: detail.payload }
+    case 'stripe':
+      return { type: 'stripe', data: detail.payload }
     default:
       throw new Error(`Unsupported payment detail type: ${(detail as { type?: string }).type ?? 'unknown'}`)
   }

--- a/frontend/src/payments/stores/paymentInfo.store.ts
+++ b/frontend/src/payments/stores/paymentInfo.store.ts
@@ -7,6 +7,7 @@ import {
   type KakaoPaymentInfo,
   type MethodUrlInfo,
   type PaymentMethodDetail,
+  type StripePaymentInfo,
   type TossPaymentInfo,
   type TransferPaymentInfo,
 } from '@/payments/services/paymentInfoService'
@@ -87,6 +88,11 @@ export const usePaymentInfoStore = defineStore('payment-info', () => {
     return detail && detail.type === 'kakao' ? detail.data : null
   })
 
+  const stripeCardInfo = computed<StripePaymentInfo | null>(() => {
+    const detail = details.value.card
+    return detail && detail.type === 'stripe' ? detail.data : null
+  })
+
   const getMethodInfo = (methodId: string): MethodUrlInfo | null => {
     const detail = getDetail(methodId)
     return detail && detail.type === 'url' ? detail.data : null
@@ -130,6 +136,7 @@ export const usePaymentInfoStore = defineStore('payment-info', () => {
     transferInfo,
     tossInfo,
     kakaoInfo,
+    stripeCardInfo,
     ensureMethodInfo,
     fetchMethodInfo,
     getDeepLinkInfo,


### PR DESCRIPTION
## Summary
- add a Node/Express backend that creates Stripe payment intents and reads API keys from a dedicated config file
- wire the card payment option to the Stripe Payment Element with a new Vue experience component and localized copy
- update test responses and payment method services to deliver Stripe client secrets when running on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0b207e42c832cb7c9c71ee656b481