### PR TITLE
Improve dark theme accessibility

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -81,6 +81,12 @@ const { t } = useI18n();
   background-color: color-mix(in srgb, var(--primary-200) 15%, transparent);
 }
 
+.nav-link:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--primary-color) 55%, transparent);
+  outline-offset: 2px;
+  color: var(--text-color);
+}
+
 .nav-link.is-active {
   color: var(--primary-color);
   background-color: color-mix(in srgb, var(--primary-200) 30%, transparent);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -69,6 +69,11 @@ main {
   transition: background 0.2s ease;
 }
 
+html.dark-mode .surface-card {
+  background: color-mix(in srgb, var(--surface-0) 92%, black 8%);
+  color: var(--text-color);
+}
+
 .text-secondary {
   color: var(--text-color-secondary);
 }
@@ -99,8 +104,14 @@ html.dark-mode .p-listbox .p-listbox-option {
 }
 
 html.dark-mode .p-listbox .p-listbox-option.p-highlight {
-  background: color-mix(in srgb, var(--primary-color) 25%, transparent);
-  color: var(--text-color);
+  background: var(--primary-500);
+  color: #0b1120;
+  font-weight: 600;
+}
+
+.p-listbox .p-listbox-option:focus-visible {
+  outline: 2px solid var(--primary-500);
+  outline-offset: 2px;
 }
 
 .container-narrow {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -157,6 +157,12 @@ const componentCards = computed(() =>
   text-decoration: none;
 }
 
+.component-card__link:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--primary-500) 70%, transparent);
+  outline-offset: 3px;
+  border-radius: 999px;
+}
+
 @media (max-width: 768px) {
   .hero__content {
     padding: 2.5rem 1.75rem;


### PR DESCRIPTION
## Summary
- darken surface card backgrounds in dark mode to preserve readable contrast
- adjust listbox highlight colors and focus outlines for better accessibility
- add visible focus states to navigation and home page links for keyboard users

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e14b367534832c87d8b7a4499db5cb