### PR TITLE
Fix dark surfaces and improve accessibility for navigation and listbox

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -76,6 +76,11 @@ const { t } = useI18n();
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
+.nav-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary-color) 55%, transparent);
+  outline-offset: 2px;
+}
+
 .nav-link:hover {
   color: var(--text-color);
   background-color: color-mix(in srgb, var(--primary-200) 15%, transparent);
@@ -90,6 +95,12 @@ const { t } = useI18n();
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.brand:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary-color) 55%, transparent);
+  outline-offset: 4px;
+  border-radius: 999px;
 }
 
 @media (max-width: 768px) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,11 @@ import App from './App.vue';
 import PrimeVue from 'primevue/config';
 import router from './router';
 import { i18n } from './locales';
-import './styles/main.css';
 import 'primevue/resources/themes/aura-light-noir/theme.css';
 import 'primevue/resources/primevue.min.css';
 import 'primeflex/primeflex.css';
 import 'primeicons/primeicons.css';
+import './styles/main.css';
 
 const app = createApp(App);
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -26,14 +26,26 @@
   --text-color: #1f2933;
   --text-color-secondary: #5f6c7b;
   --surface-0: #ffffff;
-  --surface-100: #f4f5f7;
+  --surface-50: #f8fafc;
+  --surface-100: #f1f5f9;
+  --surface-200: #e6eaf3;
   --surface-300: #d9dde5;
   --surface-700: #3d4754;
+  --surface-card: var(--surface-0);
+  --surface-section: #ffffff;
+  --surface-overlay: #ffffff;
+  --surface-border: #d1d7e2;
+  --surface-hover: color-mix(in srgb, var(--primary-200) 18%, transparent);
   --primary-200: #d6e4ff;
   --primary-400: #7698ff;
   --primary-500: #5c7cfa;
   --primary-600: #4b6ddf;
   --primary-color: #4c6fff;
+  --primary-color-text: #ffffff;
+  --highlight-bg: color-mix(in srgb, var(--primary-color) 14%, #eef2ff);
+  --highlight-text-color: #1b2551;
+  --focus-ring: 0 0 0 3px color-mix(in srgb, var(--primary-color) 35%, transparent);
+  --p-focus-ring-color: color-mix(in srgb, var(--primary-color) 55%, transparent);
 }
 
 html.dark-mode {
@@ -42,14 +54,26 @@ html.dark-mode {
   --text-color: #f9fafb;
   --text-color-secondary: #cbd5f5;
   --surface-0: #1f2937;
+  --surface-50: #161f2e;
   --surface-100: #1a2333;
+  --surface-200: #202c42;
   --surface-300: #273447;
   --surface-700: #e2e8f0;
+  --surface-card: color-mix(in srgb, var(--surface-0) 96%, transparent);
+  --surface-section: #192334;
+  --surface-overlay: #1c2739;
+  --surface-border: #2e3b4f;
+  --surface-hover: color-mix(in srgb, var(--primary-color) 22%, transparent);
   --primary-200: #334155;
   --primary-400: #7c9bff;
   --primary-500: #8ea5ff;
   --primary-600: #a3b4ff;
   --primary-color: #a5b8ff;
+  --primary-color-text: #0b1120;
+  --highlight-bg: color-mix(in srgb, var(--primary-color) 45%, #111b2b);
+  --highlight-text-color: #0b1120;
+  --focus-ring: 0 0 0 3px color-mix(in srgb, var(--primary-color) 55%, transparent);
+  --p-focus-ring-color: color-mix(in srgb, var(--primary-color) 65%, transparent);
 }
 
 html.dark-mode body {
@@ -65,8 +89,9 @@ main {
 }
 
 .surface-card {
-  background: var(--surface-0);
-  transition: background 0.2s ease;
+  background: var(--surface-card);
+  color: var(--text-color);
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .text-secondary {
@@ -79,27 +104,54 @@ main {
   font-family: inherit;
 }
 
-html.dark-mode .p-component {
+.p-component {
+  color: var(--text-color);
+}
+
+.p-component .p-highlight {
+  background: var(--highlight-bg);
+  color: var(--highlight-text-color);
+}
+
+.p-inputtext,
+.p-inputtextarea,
+.p-inputnumber-input,
+.p-dropdown {
+  color: inherit;
+}
+
+.p-listbox {
+  background: var(--surface-card);
+  color: var(--text-color);
+  border-color: color-mix(in srgb, var(--surface-border) 80%, transparent);
+}
+
+.p-listbox .p-listbox-header {
+  background: var(--surface-card);
+  color: var(--text-color);
+}
+
+.p-listbox .p-listbox-item {
+  color: var(--text-color);
+}
+
+.p-listbox .p-listbox-item.p-highlight {
+  background: var(--highlight-bg);
+  color: var(--highlight-text-color);
+}
+
+.p-listbox .p-listbox-item:not(.p-highlight):not(.p-disabled):hover,
+.p-listbox .p-listbox-item:not(.p-highlight):not(.p-disabled).p-focus {
+  background: var(--surface-hover);
   color: var(--text-color);
 }
 
 html.dark-mode .p-inputtext,
 html.dark-mode .p-inputtextarea,
 html.dark-mode .p-inputnumber-input,
-html.dark-mode .p-listbox,
-html.dark-mode .p-dropdown,
-html.dark-mode .p-button {
-  background-color: color-mix(in srgb, var(--surface-0) 40%, transparent);
-  border-color: color-mix(in srgb, var(--surface-300) 50%, transparent);
-  color: var(--text-color);
-}
-
-html.dark-mode .p-listbox .p-listbox-option {
-  color: var(--text-color);
-}
-
-html.dark-mode .p-listbox .p-listbox-option.p-highlight {
-  background: color-mix(in srgb, var(--primary-color) 25%, transparent);
+html.dark-mode .p-dropdown {
+  background-color: color-mix(in srgb, var(--surface-card) 94%, transparent);
+  border-color: color-mix(in srgb, var(--surface-border) 70%, transparent);
   color: var(--text-color);
 }
 

--- a/src/views/ComponentPlaygroundView.vue
+++ b/src/views/ComponentPlaygroundView.vue
@@ -240,6 +240,11 @@ const isOverlay = computed(() => activeDefinition.value?.id.includes('overlay') 
   color: var(--primary-color);
 }
 
+.p-listbox-item.p-highlight .component-option h3,
+.p-listbox-item.p-highlight .component-option p {
+  color: var(--highlight-text-color);
+}
+
 .playground__content {
   display: flex;
   flex-direction: column;

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -157,6 +157,12 @@ const componentCards = computed(() =>
   text-decoration: none;
 }
 
+.component-card__link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--primary-color) 55%, transparent);
+  outline-offset: 4px;
+  border-radius: 999px;
+}
+
 @media (max-width: 768px) {
   .hero__content {
     padding: 2.5rem 1.75rem;


### PR DESCRIPTION
## Summary
- reorder global style imports so custom tokens override the PrimeVue theme
- expand design tokens and component overrides to ensure dark surfaces and accessible selection contrast
- add focus-visible styles for navigation and card links to improve keyboard visibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e14b367534832c87d8b7a4499db5cb