### PR TITLE
Add content-type headers for TypeScript modules

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,11 @@
+/*
+  X-Content-Type-Options: nosniff
+
+/src/*
+  Content-Type: application/javascript; charset=utf-8
+
+/src/**/*.ts
+  Content-Type: application/javascript; charset=utf-8
+
+/*.ts
+  Content-Type: application/javascript; charset=utf-8


### PR DESCRIPTION
## Summary
- add a public `_headers` file that forces `.ts` assets to be served with `application/javascript`
- prevent browsers from rejecting module scripts due to `video/mp2t` MIME type

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1701c1bc4832c930dbb3f50f059ba