### PR TITLE
Adjust overlay defaults and loading spinner

### DIFF
--- a/src/components/library/BlurOverlay.vue
+++ b/src/components/library/BlurOverlay.vue
@@ -9,7 +9,7 @@ const props = withDefaults(
   }>(),
   {
     visible: true,
-    blur: 12,
+    blur: 7,
     overlayColor: 'rgba(15, 23, 42, 0.45)',
   }
 )

--- a/src/components/library/LoadingOverlay.vue
+++ b/src/components/library/LoadingOverlay.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import ProgressSpinner from 'primevue/progressspinner'
 import BlurOverlay from './BlurOverlay.vue'
 
 const props = withDefaults(
@@ -12,7 +11,7 @@ const props = withDefaults(
   }>(),
   {
     visible: false,
-    blur: 14,
+    blur: 7,
     description: '',
     overlayColor: 'rgba(15, 23, 42, 0.55)',
   }
@@ -28,7 +27,7 @@ const hasDescription = computed(() => Boolean(props.description?.trim()))
     </template>
     <template #overlay>
       <div class="flex flex-col items-center gap-4 text-center text-white" aria-live="polite">
-        <ProgressSpinner style="width: 3rem; height: 3rem" strokeWidth="4" aria-hidden="true" />
+        <div class="h-12 w-12 animate-spin rounded-full border-4 border-white/20 border-t-white" aria-hidden="true" />
         <p v-if="hasDescription" class="max-w-xs text-sm text-white/80">{{ props.description }}</p>
       </div>
     </template>


### PR DESCRIPTION
## Summary
- set the default blur strength for BlurOverlay and LoadingOverlay components to 7 for consistency
- replace the PrimeVue progress spinner in LoadingOverlay with a Tailwind-based animate-spin loader

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e179e6630c832cba04b7d74764a0bb