### PR TITLE
Refine spin timer with reusable progress spinner

### DIFF
--- a/src/components/library/LoadingOverlay.vue
+++ b/src/components/library/LoadingOverlay.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import BlurOverlay from './BlurOverlay.vue'
+import ProgressSpinner from './ProgressSpinner.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -8,12 +9,22 @@ const props = withDefaults(
     blur?: number
     description?: string
     overlayColor?: string
+    spinnerSize?: number
+    spinnerThickness?: number
+    spinnerTrackColor?: string
+    spinnerIndicatorColor?: string
+    spinnerLabel?: string
   }>(),
   {
     visible: false,
     blur: 7,
     description: '',
     overlayColor: 'rgba(15, 23, 42, 0.55)',
+    spinnerSize: 48,
+    spinnerThickness: 4,
+    spinnerTrackColor: 'rgba(255, 255, 255, 0.25)',
+    spinnerIndicatorColor: '#ffffff',
+    spinnerLabel: '',
   }
 )
 
@@ -27,7 +38,13 @@ const hasDescription = computed(() => Boolean(props.description?.trim()))
     </template>
     <template #overlay>
       <div class="flex flex-col items-center gap-4 text-center text-white" aria-live="polite">
-        <div class="h-12 w-12 animate-spin rounded-full border-4 border-white/20 border-t-white" aria-hidden="true" />
+        <ProgressSpinner
+          :size="props.spinnerSize"
+          :thickness="props.spinnerThickness"
+          :track-color="props.spinnerTrackColor"
+          :indicator-color="props.spinnerIndicatorColor"
+          :label="props.spinnerLabel"
+        />
         <p v-if="hasDescription" class="max-w-xs text-sm text-white/80">{{ props.description }}</p>
       </div>
     </template>

--- a/src/components/library/ProgressSpinner.vue
+++ b/src/components/library/ProgressSpinner.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+type AriaLive = 'polite' | 'assertive' | 'off'
+
+const props = withDefaults(
+  defineProps<{
+    size?: number
+    thickness?: number
+    trackColor?: string
+    indicatorColor?: string
+    label?: string
+    ariaLive?: AriaLive
+  }>(),
+  {
+    size: 48,
+    thickness: 4,
+    trackColor: 'rgba(148, 163, 184, 0.35)',
+    indicatorColor: '#6366f1',
+    label: '',
+    ariaLive: 'polite' as AriaLive,
+  }
+)
+
+const dimensions = computed(() => ({
+  width: `${props.size}px`,
+  height: `${props.size}px`,
+}))
+
+const ringStyle = computed(() => ({
+  borderWidth: `${props.thickness}px`,
+  borderColor: props.trackColor,
+  borderTopColor: props.indicatorColor,
+}))
+
+const accessibleLabel = computed(() => props.label?.trim() || undefined)
+const liveRegionRole = computed(() => (accessibleLabel.value ? 'status' : undefined))
+const ariaLive = computed(() => (accessibleLabel.value ? props.ariaLive : undefined))
+const isHiddenFromScreenReaders = computed(() => (!accessibleLabel.value ? true : undefined))
+</script>
+
+<template>
+  <div
+    class="relative inline-flex items-center justify-center"
+    :style="dimensions"
+    :role="liveRegionRole"
+    :aria-label="accessibleLabel"
+    :aria-live="ariaLive"
+    :aria-hidden="isHiddenFromScreenReaders"
+  >
+    <div
+      v-if="$slots.default"
+      class="pointer-events-none absolute inset-0 flex items-center justify-center"
+      aria-hidden="true"
+    >
+      <slot />
+    </div>
+    <div class="h-full w-full animate-spin rounded-full border-solid border-current" :style="ringStyle" />
+  </div>
+</template>

--- a/src/components/library/SpinTimer.vue
+++ b/src/components/library/SpinTimer.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import ProgressSpinner from './ProgressSpinner.vue'
+
+const props = withDefaults(
+  defineProps<{
+    value: string | number
+    size?: number
+    thickness?: number
+    textSize?: number
+    trackColor?: string
+    indicatorColor?: string
+    label?: string
+  }>(),
+  {
+    size: 96,
+    thickness: 8,
+    textSize: 22,
+    trackColor: 'rgba(148, 163, 184, 0.35)',
+    indicatorColor: '#6366f1',
+    label: '',
+  }
+)
+
+const displayValue = computed(() => `${props.value}`)
+const textStyle = computed(() => ({
+  fontSize: `${props.textSize}px`,
+  lineHeight: '1',
+}))
+</script>
+
+<template>
+  <ProgressSpinner
+    :size="props.size"
+    :thickness="props.thickness"
+    :track-color="props.trackColor"
+    :indicator-color="props.indicatorColor"
+    :label="props.label"
+  >
+    <div
+      class="flex items-center justify-center font-semibold text-slate-700 dark:text-slate-100"
+      :style="textStyle"
+      aria-hidden="true"
+    >
+      {{ displayValue }}
+    </div>
+  </ProgressSpinner>
+</template>

--- a/src/demos/LoadingOverlayDemo.vue
+++ b/src/demos/LoadingOverlayDemo.vue
@@ -6,6 +6,11 @@ defineProps<{
   blur: number
   description: string
   overlayColor?: string
+  spinnerSize?: number
+  spinnerThickness?: number
+  spinnerTrackColor?: string
+  spinnerIndicatorColor?: string
+  spinnerLabel?: string
 }>()
 </script>
 

--- a/src/demos/SpinTimerDemo.vue
+++ b/src/demos/SpinTimerDemo.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import SpinTimer from '@/components/library/SpinTimer.vue'
+
+defineProps<{
+  value: string | number
+  size: number
+  thickness: number
+  textSize: number
+  trackColor: string
+  indicatorColor: string
+  label?: string
+}>()
+</script>
+
+<template>
+  <div class="grid gap-6 rounded-3xl bg-white p-8 text-slate-800 shadow-soft dark:bg-slate-900 dark:text-slate-100">
+    <div class="flex flex-col items-center gap-4 text-center">
+      <SpinTimer v-bind="$props" />
+      <p class="text-sm text-slate-600 dark:text-slate-300">
+        Adjust the timer value, text size, and ring colors to match your countdown experience.
+      </p>
+    </div>
+  </div>
+</template>

--- a/src/library/catalog.ts
+++ b/src/library/catalog.ts
@@ -33,6 +33,82 @@ export interface LabComponentDefinition {
 
 export const componentCatalog: LabComponentDefinition[] = [
   {
+    id: 'spin-timer',
+    name: {
+      en: 'Spin Timer',
+      ko: '스핀 타이머',
+    },
+    description: {
+      en: 'Animated circular timer with a centered, size-adjustable value.',
+      ko: '중앙 값의 크기를 조절할 수 있는 회전형 원형 타이머입니다.',
+    },
+    component: () => import('@/components/library/SpinTimer.vue'),
+    preview: () => import('@/demos/SpinTimerDemo.vue'),
+    defaultProps: {
+      value: '25s',
+      size: 112,
+      thickness: 10,
+      textSize: 24,
+      indicatorColor: '#6366f1',
+      trackColor: 'rgba(148, 163, 184, 0.35)',
+      label: 'Remaining time 25 seconds',
+    },
+    controls: [
+      {
+        key: 'value',
+        type: 'text',
+        label: { en: 'Value', ko: '값' },
+        helperText: {
+          en: 'Text or number displayed at the center of the timer.',
+          ko: '타이머 중앙에 표시할 텍스트 또는 숫자입니다.',
+        },
+      },
+      {
+        key: 'size',
+        type: 'slider',
+        label: { en: 'Diameter', ko: '지름' },
+        min: 48,
+        max: 192,
+        step: 4,
+      },
+      {
+        key: 'thickness',
+        type: 'slider',
+        label: { en: 'Ring Thickness', ko: '테두리 두께' },
+        min: 2,
+        max: 20,
+        step: 1,
+      },
+      {
+        key: 'textSize',
+        type: 'slider',
+        label: { en: 'Text Size', ko: '텍스트 크기' },
+        min: 12,
+        max: 48,
+        step: 1,
+      },
+      {
+        key: 'indicatorColor',
+        type: 'color',
+        label: { en: 'Indicator Color', ko: '인디케이터 색상' },
+      },
+      {
+        key: 'trackColor',
+        type: 'color',
+        label: { en: 'Track Color', ko: '트랙 색상' },
+      },
+      {
+        key: 'label',
+        type: 'text',
+        label: { en: 'Accessible Label', ko: '접근성 레이블' },
+        helperText: {
+          en: 'Optional description read by screen readers.',
+          ko: '스크린 리더가 읽어 주는 선택적 설명입니다.',
+        },
+      },
+    ],
+  },
+  {
     id: 'qr-code',
     name: {
       en: 'QR Code',
@@ -130,8 +206,8 @@ export const componentCatalog: LabComponentDefinition[] = [
       ko: '로딩 오버레이',
     },
     description: {
-      en: 'Displays a PrimeVue spinner with optional description over blurred content.',
-      ko: '블러 처리된 콘텐츠 위에 설명이 포함된 PrimeVue 스피너를 표시합니다.',
+      en: 'Displays a reusable progress spinner with optional description over blurred content.',
+      ko: '블러 처리된 콘텐츠 위에 재사용 가능한 프로그레스 스피너와 설명을 표시합니다.',
     },
     component: () => import('@/components/library/LoadingOverlay.vue'),
     preview: () => import('@/demos/LoadingOverlayDemo.vue'),


### PR DESCRIPTION
## Summary
- extract a reusable ProgressSpinner component and wire it into the SpinTimer and LoadingOverlay implementations
- allow the SpinTimer text size to be configured and streamline its playground demo copy
- refresh the catalog metadata to surface the new timer control and updated loading overlay description

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17baf1ec4832cb14df359b2a73d96