### PR TITLE
Rename spin timer to shared spinner

### DIFF
--- a/src/components/library/LoadingOverlay.vue
+++ b/src/components/library/LoadingOverlay.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import BlurOverlay from './BlurOverlay.vue'
+import Spinner from './Spinner.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -8,12 +9,22 @@ const props = withDefaults(
     blur?: number
     description?: string
     overlayColor?: string
+    spinnerSize?: number
+    spinnerThickness?: number
+    spinnerTrackColor?: string
+    spinnerIndicatorColor?: string
+    spinnerText?: string | number
   }>(),
   {
     visible: false,
     blur: 7,
     description: '',
     overlayColor: 'rgba(15, 23, 42, 0.55)',
+    spinnerSize: 48,
+    spinnerThickness: 4,
+    spinnerTrackColor: 'rgba(255, 255, 255, 0.25)',
+    spinnerIndicatorColor: '#ffffff',
+    spinnerText: '',
   }
 )
 
@@ -27,7 +38,14 @@ const hasDescription = computed(() => Boolean(props.description?.trim()))
     </template>
     <template #overlay>
       <div class="flex flex-col items-center gap-4 text-center text-white" aria-live="polite">
-        <div class="h-12 w-12 animate-spin rounded-full border-4 border-white/20 border-t-white" aria-hidden="true" />
+        <Spinner
+          :size="props.spinnerSize"
+          :thickness="props.spinnerThickness"
+          :track-color="props.spinnerTrackColor"
+          :indicator-color="props.spinnerIndicatorColor"
+          :text="props.spinnerText"
+          :text-size="18"
+        />
         <p v-if="hasDescription" class="max-w-xs text-sm text-white/80">{{ props.description }}</p>
       </div>
     </template>

--- a/src/components/library/Spinner.vue
+++ b/src/components/library/Spinner.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    text?: string | number
+    size?: number
+    thickness?: number
+    textSize?: number
+    trackColor?: string
+    indicatorColor?: string
+  }>(),
+  {
+    text: '',
+    size: 96,
+    thickness: 8,
+    textSize: 22,
+    trackColor: 'rgba(148, 163, 184, 0.35)',
+    indicatorColor: '#6366f1',
+  }
+)
+
+const displayText = computed(() => `${props.text ?? ''}`)
+const trimmedText = computed(() => displayText.value.trim())
+const hasText = computed(() => trimmedText.value.length > 0)
+
+const textStyle = computed(() => ({
+  fontSize: `${props.textSize}px`,
+  lineHeight: '1',
+}))
+
+const dimensions = computed(() => ({
+  width: `${props.size}px`,
+  height: `${props.size}px`,
+}))
+
+const ringStyle = computed(() => ({
+  borderWidth: `${props.thickness}px`,
+  borderColor: props.trackColor,
+  borderTopColor: props.indicatorColor,
+}))
+
+const accessibleLabel = computed(() => (trimmedText.value ? trimmedText.value : undefined))
+const ariaLive = computed(() => (accessibleLabel.value ? 'polite' : undefined))
+const ariaHidden = computed(() => (!accessibleLabel.value ? true : undefined))
+const liveRegionRole = computed(() => (accessibleLabel.value ? 'status' : undefined))
+</script>
+
+<template>
+  <div
+    class="relative inline-flex items-center justify-center"
+    :style="dimensions"
+    :role="liveRegionRole"
+    :aria-label="accessibleLabel"
+    :aria-live="ariaLive"
+    :aria-hidden="ariaHidden"
+  >
+    <div
+      v-if="hasText"
+      class="pointer-events-none absolute inset-0 flex items-center justify-center font-semibold text-slate-700 dark:text-slate-100"
+      :style="textStyle"
+      aria-hidden="true"
+    >
+      {{ displayText }}
+    </div>
+    <div class="h-full w-full animate-spin rounded-full border-solid border-current" :style="ringStyle" />
+  </div>
+</template>

--- a/src/demos/LoadingOverlayDemo.vue
+++ b/src/demos/LoadingOverlayDemo.vue
@@ -6,6 +6,11 @@ defineProps<{
   blur: number
   description: string
   overlayColor?: string
+  spinnerSize?: number
+  spinnerThickness?: number
+  spinnerTrackColor?: string
+  spinnerIndicatorColor?: string
+  spinnerText?: string | number
 }>()
 </script>
 

--- a/src/demos/SpinnerDemo.vue
+++ b/src/demos/SpinnerDemo.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import Spinner from '@/components/library/Spinner.vue'
+
+defineProps<{
+  text?: string | number
+  size: number
+  thickness: number
+  textSize: number
+  trackColor: string
+  indicatorColor: string
+}>()
+</script>
+
+<template>
+  <div class="grid gap-6 rounded-3xl bg-white p-8 text-slate-800 shadow-soft dark:bg-slate-900 dark:text-slate-100">
+    <div class="flex flex-col items-center gap-4 text-center">
+      <Spinner v-bind="$props" />
+      <p class="text-sm text-slate-600 dark:text-slate-300">
+        Tune the animated spinner to match your loading experience.
+      </p>
+    </div>
+  </div>
+</template>

--- a/src/library/catalog.ts
+++ b/src/library/catalog.ts
@@ -33,6 +33,72 @@ export interface LabComponentDefinition {
 
 export const componentCatalog: LabComponentDefinition[] = [
   {
+    id: 'spinner',
+    name: {
+      en: 'Spinner',
+      ko: '스피너',
+    },
+    description: {
+      en: 'Animated circular spinner with optional centered text sizing.',
+      ko: '중앙 텍스트 크기를 조절할 수 있는 회전형 스피너입니다.',
+    },
+    component: () => import('@/components/library/Spinner.vue'),
+    preview: () => import('@/demos/SpinnerDemo.vue'),
+    defaultProps: {
+      text: '25s',
+      size: 112,
+      thickness: 10,
+      textSize: 24,
+      indicatorColor: '#6366f1',
+      trackColor: 'rgba(148, 163, 184, 0.35)',
+    },
+    controls: [
+      {
+        key: 'text',
+        type: 'text',
+        label: { en: 'Text', ko: '텍스트' },
+        helperText: {
+          en: 'Content displayed at the center of the spinner.',
+          ko: '스피너 중앙에 표시할 텍스트입니다.',
+        },
+      },
+      {
+        key: 'size',
+        type: 'slider',
+        label: { en: 'Diameter', ko: '지름' },
+        min: 48,
+        max: 192,
+        step: 4,
+      },
+      {
+        key: 'thickness',
+        type: 'slider',
+        label: { en: 'Ring Thickness', ko: '테두리 두께' },
+        min: 2,
+        max: 20,
+        step: 1,
+      },
+      {
+        key: 'textSize',
+        type: 'slider',
+        label: { en: 'Text Size', ko: '텍스트 크기' },
+        min: 12,
+        max: 48,
+        step: 1,
+      },
+      {
+        key: 'indicatorColor',
+        type: 'color',
+        label: { en: 'Indicator Color', ko: '인디케이터 색상' },
+      },
+      {
+        key: 'trackColor',
+        type: 'color',
+        label: { en: 'Track Color', ko: '트랙 색상' },
+      },
+    ],
+  },
+  {
     id: 'qr-code',
     name: {
       en: 'QR Code',
@@ -130,8 +196,8 @@ export const componentCatalog: LabComponentDefinition[] = [
       ko: '로딩 오버레이',
     },
     description: {
-      en: 'Displays a PrimeVue spinner with optional description over blurred content.',
-      ko: '블러 처리된 콘텐츠 위에 설명이 포함된 PrimeVue 스피너를 표시합니다.',
+      en: 'Displays the shared spinner with optional text and description over blurred content.',
+      ko: '블러 처리된 콘텐츠 위에 공유 스피너와 선택적인 텍스트·설명을 표시합니다.',
     },
     component: () => import('@/components/library/LoadingOverlay.vue'),
     preview: () => import('@/demos/LoadingOverlayDemo.vue'),


### PR DESCRIPTION
## Summary
- replace the SpinTimer implementation with a reusable Spinner that drives the animated ring and text display
- remove the legacy ProgressSpinner, update LoadingOverlay to consume the new spinner API, and add spinner text support
- refresh the spinner and loading overlay demos and catalog copy to reflect the renamed component and shared loading behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17baf1ec4832cb14df359b2a73d96