### PR TITLE
Enhance loading overlay controls in catalog

### DIFF
--- a/src/library/catalog.ts
+++ b/src/library/catalog.ts
@@ -206,6 +206,11 @@ export const componentCatalog: LabComponentDefinition[] = [
       blur: 18,
       description: 'Fetching your dashboard data...',
       overlayColor: 'rgba(15, 23, 42, 0.55)',
+      spinnerSize: 72,
+      spinnerThickness: 6,
+      spinnerTrackColor: 'rgba(255, 255, 255, 0.2)',
+      spinnerIndicatorColor: '#facc15',
+      spinnerText: 'Syncing',
     },
     controls: [
       {
@@ -229,6 +234,41 @@ export const componentCatalog: LabComponentDefinition[] = [
           en: 'Text shown under the spinner. Leave empty to hide.',
           ko: '스피너 아래에 표시되는 문구입니다. 비워두면 숨겨집니다.',
         },
+      },
+      {
+        key: 'spinnerText',
+        type: 'text',
+        label: { en: 'Spinner Text', ko: '스피너 텍스트' },
+        helperText: {
+          en: 'Optional center text inside the spinner. Supports numbers or short phrases.',
+          ko: '스피너 중앙에 표시할 선택적 텍스트입니다. 숫자나 짧은 문구를 사용할 수 있습니다.',
+        },
+      },
+      {
+        key: 'spinnerSize',
+        type: 'slider',
+        label: { en: 'Spinner Size', ko: '스피너 크기' },
+        min: 32,
+        max: 160,
+        step: 4,
+      },
+      {
+        key: 'spinnerThickness',
+        type: 'slider',
+        label: { en: 'Spinner Thickness', ko: '스피너 두께' },
+        min: 2,
+        max: 16,
+        step: 1,
+      },
+      {
+        key: 'spinnerIndicatorColor',
+        type: 'color',
+        label: { en: 'Indicator Color', ko: '인디케이터 색상' },
+      },
+      {
+        key: 'spinnerTrackColor',
+        type: 'color',
+        label: { en: 'Track Color', ko: '트랙 색상' },
       },
       {
         key: 'overlayColor',


### PR DESCRIPTION
## Summary
- expose spinner size, thickness, colors, and text for the loading overlay playground controls
- seed the catalog defaults with refreshed spinner styling values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1863f8008832cb196aafe7da1a537