### PR TITLE
Align Tailwind theme tokens with PrimeVue colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.15",
+        "tailwindcss-primeui": "^0.6.1",
         "typescript": "~5.9.3",
         "vite": "^7.1.7",
         "vue-tsc": "^3.1.0"
@@ -2844,6 +2845,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-primeui": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss-primeui/-/tailwindcss-primeui-0.6.1.tgz",
+      "integrity": "sha512-T69Rylcrmnt8zy9ik+qZvsLuRIrS9/k6rYJSIgZ1trnbEzGDDQSCIdmfyZknevqiHwpSJHSmQ9XT2C+S/hJY4A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.1.0"
       }
     },
     "node_modules/thenify": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.15",
+    "tailwindcss-primeui": "^0.6.1",
     "typescript": "~5.9.3",
     "vite": "^7.1.7",
     "vue-tsc": "^3.1.0"

--- a/src/style.css
+++ b/src/style.css
@@ -5,12 +5,12 @@
 @layer base {
   :root {
     color-scheme: light;
-    @apply font-sans text-slate-800 bg-surface-50;
+    @apply font-sans text-surface-900 bg-surface-0;
   }
 
   :root.dark {
     color-scheme: dark;
-    @apply text-slate-100 bg-slate-950;
+    @apply text-surface-0 bg-surface-900;
   }
 
   body {
@@ -18,12 +18,12 @@
   }
 
   a {
-    @apply text-primary-500 hover:text-primary-400 transition-colors;
+    @apply text-primary hover:text-primary-emphasis transition-colors;
   }
 }
 
 @layer components {
   .card-surface {
-    @apply bg-white dark:bg-slate-900/70 rounded-2xl shadow-soft border border-slate-200/70 dark:border-slate-700/70;
+    @apply bg-surface-0 dark:bg-surface-900 rounded-2xl shadow-soft border border-surface-100 dark:border-surface-800;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import primeui from 'tailwindcss-primeui'
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
@@ -8,29 +10,10 @@ export default {
         sans: ['"Noto Sans KR"', 'Inter', 'ui-sans-serif', 'system-ui'],
         display: ['"Noto Sans KR"', 'Inter', 'ui-sans-serif', 'system-ui'],
       },
-      colors: {
-        primary: {
-          50: '#eef6ff',
-          100: '#dbeafe',
-          200: '#bfdbfe',
-          300: '#93c5fd',
-          400: '#60a5fa',
-          500: '#3b82f6',
-          600: '#2563eb',
-          700: '#1d4ed8',
-          800: '#1e40af',
-          900: '#1e3a8a',
-        },
-        surface: {
-          50: '#f8fafc',
-          100: '#f1f5f9',
-          900: '#0f172a',
-        },
-      },
       boxShadow: {
         soft: '0 20px 45px -20px rgba(15, 23, 42, 0.35)',
       },
     },
   },
-  plugins: [],
+  plugins: [primeui],
 }


### PR DESCRIPTION
## Summary
- add the tailwindcss-primeui plugin so Tailwind utilities inherit PrimeVue theme tokens
- update base surface and link styles to rely on PrimeVue color variables for consistent defaults

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e186c5a8cc832ca4778a7618e440dc