### PR TITLE
Integrate tailwindcss-primeui theme colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.15",
+        "tailwindcss-primeui": "^0.6.1",
         "typescript": "~5.9.3",
         "vite": "^7.1.7",
         "vue-tsc": "^3.1.0"
@@ -2844,6 +2845,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-primeui": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss-primeui/-/tailwindcss-primeui-0.6.1.tgz",
+      "integrity": "sha512-T69Rylcrmnt8zy9ik+qZvsLuRIrS9/k6rYJSIgZ1trnbEzGDDQSCIdmfyZknevqiHwpSJHSmQ9XT2C+S/hJY4A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.1.0"
       }
     },
     "node_modules/thenify": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.15",
+    "tailwindcss-primeui": "^0.6.1",
     "typescript": "~5.9.3",
     "vite": "^7.1.7",
     "vue-tsc": "^3.1.0"

--- a/src/App.vue
+++ b/src/App.vue
@@ -91,17 +91,17 @@ watch(
 </script>
 
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-surface-50 via-white to-primary-50/30 text-slate-800 transition-colors dark:from-slate-950 dark:via-slate-950 dark:to-slate-900 dark:text-slate-100">
-    <header class="sticky top-0 z-40 border-b border-slate-200/70 bg-white/70 backdrop-blur dark:border-slate-800/70 dark:bg-slate-950/70">
+  <div class="min-h-screen bg-gradient-to-br from-surface-50 via-surface-0 to-primary-50/30 text-surface-800 transition-colors dark:from-surface-950 dark:via-surface-950 dark:to-surface-900 dark:text-surface-0">
+    <header class="sticky top-0 z-40 border-b border-surface-200/70 bg-surface-0/70 backdrop-blur dark:border-surface-800/70 dark:bg-surface-950/70">
       <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-5">
         <RouterLink to="/" class="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
-          <span class="text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">{{ t('app.title') }}</span>
-          <span class="text-sm text-slate-500 dark:text-slate-400">{{ t('app.tagline') }}</span>
+          <span class="text-xl font-semibold tracking-tight text-surface-900 dark:text-surface-0">{{ t('app.title') }}</span>
+          <span class="text-sm text-surface-500 dark:text-surface-300">{{ t('app.tagline') }}</span>
         </RouterLink>
         <div class="flex items-center gap-3">
           <nav
             aria-label="Language switcher"
-            class="flex rounded-full border border-slate-200/70 bg-white/80 p-1 shadow-sm backdrop-blur dark:border-slate-700/70 dark:bg-slate-800/80"
+            class="flex rounded-full border border-surface-200/70 bg-surface-0/80 p-1 shadow-sm backdrop-blur dark:border-surface-700/70 dark:bg-surface-800/80"
           >
             <button
               v-for="option in languageOptions"
@@ -110,8 +110,8 @@ watch(
               class="rounded-full px-3 py-1.5 text-sm font-medium transition-colors"
               :class="
                 locale === option.value
-                  ? 'bg-primary-500 text-white shadow-sm'
-                  : 'text-slate-600 dark:text-slate-300 hover:text-primary-500'
+                  ? 'bg-primary-500 text-primary-contrast shadow-sm'
+                  : 'text-surface-600 dark:text-surface-300 hover:text-primary-500'
               "
               @click="setLocale(option.value)"
             >
@@ -120,7 +120,7 @@ watch(
           </nav>
           <button
             type="button"
-            class="flex h-10 w-10 items-center justify-center rounded-full border border-slate-200/70 bg-white/90 text-slate-600 shadow-sm transition-colors hover:text-primary-500 dark:border-slate-700/70 dark:bg-slate-800/80 dark:text-slate-300"
+            class="flex h-10 w-10 items-center justify-center rounded-full border border-surface-200/70 bg-surface-0/90 text-surface-600 shadow-sm transition-colors hover:text-primary-500 dark:border-surface-700/70 dark:bg-surface-800/80 dark:text-surface-300"
             :title="t('app.themeToggle')"
             @click="toggleTheme"
           >

--- a/src/components/library/BlurOverlay.vue
+++ b/src/components/library/BlurOverlay.vue
@@ -10,7 +10,7 @@ const props = withDefaults(
   {
     visible: true,
     blur: 7,
-    overlayColor: 'rgba(15, 23, 42, 0.45)',
+    overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
   }
 )
 
@@ -29,7 +29,7 @@ const overlayStyle = computed(() => ({
     <transition name="fade-blur">
       <div
         v-if="props.visible"
-        class="absolute inset-0 flex items-center justify-center rounded-inherit border border-white/10 text-slate-100 backdrop-blur"
+        class="absolute inset-0 flex items-center justify-center rounded-inherit border border-surface-0/10 text-surface-0 backdrop-blur"
         :style="overlayStyle"
       >
         <div class="pointer-events-auto">

--- a/src/components/library/LoadingOverlay.vue
+++ b/src/components/library/LoadingOverlay.vue
@@ -19,11 +19,11 @@ const props = withDefaults(
     visible: false,
     blur: 7,
     description: '',
-    overlayColor: 'rgba(15, 23, 42, 0.55)',
+    overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
     spinnerSize: 48,
     spinnerThickness: 4,
-    spinnerTrackColor: 'rgba(255, 255, 255, 0.25)',
-    spinnerIndicatorColor: '#ffffff',
+    spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
+    spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
     spinnerText: '',
   }
 )
@@ -37,7 +37,7 @@ const hasDescription = computed(() => Boolean(props.description?.trim()))
       <slot />
     </template>
     <template #overlay>
-      <div class="flex flex-col items-center gap-4 text-center text-white" aria-live="polite">
+      <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
         <Spinner
           :size="props.spinnerSize"
           :thickness="props.spinnerThickness"
@@ -46,7 +46,7 @@ const hasDescription = computed(() => Boolean(props.description?.trim()))
           :text="props.spinnerText"
           :text-size="18"
         />
-        <p v-if="hasDescription" class="max-w-xs text-sm text-white/80">{{ props.description }}</p>
+        <p v-if="hasDescription" class="max-w-xs text-sm text-surface-0/80">{{ props.description }}</p>
       </div>
     </template>
   </BlurOverlay>

--- a/src/components/library/QrCode.vue
+++ b/src/components/library/QrCode.vue
@@ -10,8 +10,8 @@ const props = withDefaults(
     icon?: string
   }>(),
   {
-    lightColor: '#ffffff',
-    darkColor: '#0f172a',
+    lightColor: 'var(--p-surface-0)',
+    darkColor: 'var(--p-surface-900)',
     icon: '',
   }
 )
@@ -21,7 +21,7 @@ const hasIcon = computed(() => Boolean(props.icon?.trim()))
 
 <template>
   <section class="flex flex-col items-center text-center">
-    <div class="relative rounded-3xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+    <div class="relative rounded-3xl border border-surface-200 bg-surface-0 p-4 shadow-sm dark:border-surface-700 dark:bg-surface-900">
       <QrcodeVue
         :value="props.content"
         :size="220"
@@ -36,7 +36,7 @@ const hasIcon = computed(() => Boolean(props.icon?.trim()))
         aria-hidden="true"
       >
         <span
-          class="flex h-16 w-16 items-center justify-center rounded-2xl border-4 border-white/80 bg-white/90 shadow-lg backdrop-blur dark:border-slate-900/70 dark:bg-slate-900/80"
+          class="flex h-16 w-16 items-center justify-center rounded-2xl border-4 border-surface-0/80 bg-surface-0/90 shadow-lg backdrop-blur dark:border-surface-900/70 dark:bg-surface-900/80"
         >
           <img :src="props.icon" alt="" class="h-10 w-10 object-contain" />
         </span>

--- a/src/components/library/Spinner.vue
+++ b/src/components/library/Spinner.vue
@@ -15,8 +15,8 @@ const props = withDefaults(
     size: 96,
     thickness: 8,
     textSize: 22,
-    trackColor: 'rgba(148, 163, 184, 0.35)',
-    indicatorColor: '#6366f1',
+    trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
+    indicatorColor: 'var(--p-primary-color)',
   }
 )
 
@@ -57,7 +57,7 @@ const liveRegionRole = computed(() => (accessibleLabel.value ? 'status' : undefi
   >
     <div
       v-if="hasText"
-      class="pointer-events-none absolute inset-0 flex items-center justify-center font-semibold text-slate-700 dark:text-slate-100"
+      class="pointer-events-none absolute inset-0 flex items-center justify-center font-semibold text-surface-700 dark:text-surface-0"
       :style="textStyle"
       aria-hidden="true"
     >

--- a/src/demos/BlurOverlayDemo.vue
+++ b/src/demos/BlurOverlayDemo.vue
@@ -11,20 +11,20 @@ defineProps<{
 <template>
   <BlurOverlay v-bind="$props" class="block overflow-hidden rounded-3xl shadow-soft">
     <template #default>
-      <div class="relative h-64 w-full bg-gradient-to-br from-primary-500 via-slate-900 to-slate-800">
-        <div class="flex h-full flex-col justify-between p-8 text-white">
+      <div class="relative h-64 w-full bg-gradient-to-br from-primary-500 via-surface-900 to-surface-800">
+        <div class="flex h-full flex-col justify-between p-8 text-surface-0">
           <div>
-            <p class="text-xs font-semibold uppercase tracking-[0.4em] text-white/60">Creative focus</p>
+            <p class="text-xs font-semibold uppercase tracking-[0.4em] text-surface-0/60">Creative focus</p>
             <h3 class="mt-4 text-3xl font-semibold">Aurora Session</h3>
           </div>
-          <p class="max-w-sm text-sm text-white/70">
+          <p class="max-w-sm text-sm text-surface-0/70">
             Overlay sections help draw attention while keeping the page context visible beneath.
           </p>
         </div>
       </div>
     </template>
     <template #overlay>
-      <div class="rounded-full bg-white/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.4em] text-white/90">
+      <div class="rounded-full bg-surface-0/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.4em] text-surface-0/90">
         Overlay Active
       </div>
     </template>

--- a/src/demos/LoadingOverlayDemo.vue
+++ b/src/demos/LoadingOverlayDemo.vue
@@ -17,17 +17,17 @@ defineProps<{
 <template>
   <LoadingOverlay v-bind="$props" class="block overflow-hidden rounded-3xl shadow-soft">
     <template #default>
-      <div class="grid h-64 w-full gap-6 bg-white p-8 text-slate-800 dark:bg-slate-900 dark:text-slate-100 md:grid-cols-2">
-        <section class="flex flex-col justify-between rounded-2xl border border-slate-200/70 bg-slate-50/70 p-5 dark:border-slate-800/70 dark:bg-slate-800/50">
+      <div class="grid h-64 w-full gap-6 bg-surface-0 p-8 text-surface-800 dark:bg-surface-900 dark:text-surface-0 md:grid-cols-2">
+        <section class="flex flex-col justify-between rounded-2xl border border-surface-200/70 bg-surface-50/70 p-5 dark:border-surface-800/70 dark:bg-surface-800/50">
           <div>
             <p class="text-xs font-semibold uppercase tracking-[0.4em] text-primary-500">Sprint focus</p>
             <h3 class="mt-3 text-2xl font-semibold">Dashboard revamp</h3>
           </div>
-          <p class="text-sm text-slate-600 dark:text-slate-300">
+          <p class="text-sm text-surface-600 dark:text-surface-300">
             Current iteration tackles responsive layouts and loading experiences for the analytics hub.
           </p>
         </section>
-        <section class="flex flex-col justify-between rounded-2xl border border-slate-200/70 bg-slate-50/70 p-5 dark:border-slate-800/70 dark:bg-slate-800/50">
+        <section class="flex flex-col justify-between rounded-2xl border border-surface-200/70 bg-surface-50/70 p-5 dark:border-surface-800/70 dark:bg-surface-800/50">
           <div class="flex items-center justify-between text-sm font-medium">
             <span>Wireframes</span>
             <span class="text-primary-500">100%</span>

--- a/src/demos/SpinnerDemo.vue
+++ b/src/demos/SpinnerDemo.vue
@@ -12,10 +12,10 @@ defineProps<{
 </script>
 
 <template>
-  <div class="grid gap-6 rounded-3xl bg-white p-8 text-slate-800 shadow-soft dark:bg-slate-900 dark:text-slate-100">
+  <div class="grid gap-6 rounded-3xl bg-surface-0 p-8 text-surface-800 shadow-soft dark:bg-surface-900 dark:text-surface-0">
     <div class="flex flex-col items-center gap-4 text-center">
       <Spinner v-bind="$props" />
-      <p class="text-sm text-slate-600 dark:text-slate-300">
+      <p class="text-sm text-surface-600 dark:text-surface-300">
         Tune the animated spinner to match your loading experience.
       </p>
     </div>

--- a/src/style.css
+++ b/src/style.css
@@ -5,12 +5,12 @@
 @layer base {
   :root {
     color-scheme: light;
-    @apply font-sans text-slate-800 bg-surface-50;
+    @apply font-sans text-surface-900 bg-surface-0;
   }
 
   :root.dark {
     color-scheme: dark;
-    @apply text-slate-100 bg-slate-950;
+    @apply text-surface-0 bg-surface-950;
   }
 
   body {
@@ -24,6 +24,6 @@
 
 @layer components {
   .card-surface {
-    @apply bg-white dark:bg-slate-900/70 rounded-2xl shadow-soft border border-slate-200/70 dark:border-slate-700/70;
+    @apply bg-surface-0 dark:bg-surface-900/70 rounded-2xl shadow-soft border border-surface-200/70 dark:border-surface-700/70;
   }
 }

--- a/src/views/ComponentPlayground.vue
+++ b/src/views/ComponentPlayground.vue
@@ -71,11 +71,11 @@ watch(
     <div class="text-4xl text-primary-500">
       <i class="pi pi-compass"></i>
     </div>
-    <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">{{ t('playground.notFoundTitle') }}</h1>
-    <p class="max-w-md text-sm text-slate-600 dark:text-slate-300">{{ t('playground.notFoundDescription') }}</p>
+    <h1 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">{{ t('playground.notFoundTitle') }}</h1>
+    <p class="max-w-md text-sm text-surface-600 dark:text-surface-300">{{ t('playground.notFoundDescription') }}</p>
     <RouterLink
       to="/"
-      class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-medium text-white shadow-soft transition hover:bg-primary-400"
+      class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-medium text-primary-contrast shadow-soft transition hover:bg-primary-400"
     >
       {{ t('playground.backHome') }}
       <i class="pi pi-arrow-right text-xs"></i>
@@ -85,19 +85,19 @@ watch(
     <section class="card-surface flex flex-col gap-6 p-6">
       <header class="space-y-3">
         <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary-500">{{ t('playground.preview') }}</p>
-        <h1 class="text-3xl font-semibold text-slate-900 dark:text-slate-100">{{ localizedName }}</h1>
-        <p class="text-sm text-slate-600 dark:text-slate-300">{{ localizedDescription }}</p>
+        <h1 class="text-3xl font-semibold text-surface-900 dark:text-surface-0">{{ localizedName }}</h1>
+        <p class="text-sm text-surface-600 dark:text-surface-300">{{ localizedDescription }}</p>
       </header>
-      <div class="relative min-h-[360px] overflow-hidden rounded-3xl border border-slate-200/70 bg-white p-6 shadow-inner dark:border-slate-800/70 dark:bg-slate-900">
+      <div class="relative min-h-[360px] overflow-hidden rounded-3xl border border-surface-200/70 bg-surface-0 p-6 shadow-inner dark:border-surface-800/70 dark:bg-surface-900">
         <Suspense v-if="previewComponent">
           <component :is="previewComponent" v-bind="currentProps" />
           <template #fallback>
-            <div class="flex h-full items-center justify-center text-slate-400">
+            <div class="flex h-full items-center justify-center text-surface-400">
               <i class="pi pi-spinner animate-spin text-2xl"></i>
             </div>
           </template>
         </Suspense>
-        <div v-else class="flex h-full items-center justify-center text-slate-400">
+        <div v-else class="flex h-full items-center justify-center text-surface-400">
           <i class="pi pi-spinner animate-spin text-2xl"></i>
         </div>
       </div>
@@ -113,7 +113,7 @@ watch(
           {{ t('playground.reset') }}
         </button>
       </div>
-      <p class="text-sm text-slate-500 dark:text-slate-400">{{ t('playground.helper') }}</p>
+      <p class="text-sm text-surface-500 dark:text-surface-400">{{ t('playground.helper') }}</p>
       <form class="flex flex-col gap-5">
         <div
           v-for="control in definition.controls"
@@ -123,7 +123,7 @@ watch(
           <label
             v-if="control.type !== 'boolean'"
             :for="control.key"
-            class="font-medium text-slate-700 dark:text-slate-200"
+            class="font-medium text-surface-700 dark:text-surface-200"
           >
             {{ localize(control.label) }}
           </label>
@@ -132,7 +132,7 @@ watch(
               :id="control.key"
               v-model="(currentProps[control.key] as string | undefined)"
               type="text"
-              class="w-full rounded-xl border border-slate-200/70 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm transition focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:border-slate-700/70 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-primary-300"
+              class="w-full rounded-xl border border-surface-200/70 bg-surface-0 px-3 py-2 text-sm text-surface-700 shadow-sm transition focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:border-surface-700/70 dark:bg-surface-900 dark:text-surface-0 dark:focus:border-primary-300"
             />
           </template>
           <template v-else-if="control.type === 'textarea'">
@@ -140,7 +140,7 @@ watch(
               :id="control.key"
               v-model="(currentProps[control.key] as string | undefined)"
               rows="4"
-              class="w-full rounded-xl border border-slate-200/70 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm transition focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:border-slate-700/70 dark:bg-slate-900 dark:text-slate-100 dark:focus:border-primary-300"
+              class="w-full rounded-xl border border-surface-200/70 bg-surface-0 px-3 py-2 text-sm text-surface-700 shadow-sm transition focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:border-surface-700/70 dark:bg-surface-900 dark:text-surface-0 dark:focus:border-primary-300"
             ></textarea>
           </template>
           <template v-else-if="control.type === 'color'">
@@ -148,7 +148,7 @@ watch(
               :id="control.key"
               v-model="(currentProps[control.key] as string | undefined)"
               type="color"
-              class="h-12 w-20 cursor-pointer rounded-xl border border-slate-200/70 bg-white p-1 shadow-sm dark:border-slate-700/70 dark:bg-slate-900"
+              class="h-12 w-20 cursor-pointer rounded-xl border border-surface-200/70 bg-surface-0 p-1 shadow-sm dark:border-surface-700/70 dark:bg-surface-900"
             />
           </template>
           <template v-else-if="control.type === 'slider'">
@@ -171,12 +171,12 @@ watch(
                 :id="control.key"
                 v-model="(currentProps[control.key] as boolean | undefined)"
                 type="checkbox"
-                class="h-5 w-5 rounded border border-slate-300 text-primary-500 focus:ring-primary-200 dark:border-slate-600"
+                class="h-5 w-5 rounded border border-surface-300 text-primary-500 focus:ring-primary-200 dark:border-surface-600"
               />
-              <span class="text-sm text-slate-600 dark:text-slate-300">{{ localize(control.label) }}</span>
+              <span class="text-sm text-surface-600 dark:text-surface-300">{{ localize(control.label) }}</span>
             </label>
           </template>
-          <p v-if="control.helperText" class="text-xs text-slate-500 dark:text-slate-400">
+          <p v-if="control.helperText" class="text-xs text-surface-500 dark:text-surface-400">
             {{ localize(control.helperText) }}
           </p>
         </div>

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -24,8 +24,8 @@ const localizedComponents = computed(() =>
   <section class="space-y-4">
     <div class="space-y-3">
       <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary-500">Component Lab</p>
-      <h1 class="text-4xl font-semibold text-slate-900 dark:text-slate-100">{{ t('home.title') }}</h1>
-      <p class="max-w-2xl text-base text-slate-600 dark:text-slate-300">{{ t('home.description') }}</p>
+      <h1 class="text-4xl font-semibold text-surface-900 dark:text-surface-0">{{ t('home.title') }}</h1>
+      <p class="max-w-2xl text-base text-surface-600 dark:text-surface-300">{{ t('home.description') }}</p>
     </div>
     <div class="grid gap-6 md:grid-cols-2">
       <article
@@ -34,12 +34,12 @@ const localizedComponents = computed(() =>
         class="card-surface flex flex-col justify-between gap-6 p-6"
       >
         <div class="space-y-3">
-          <h2 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">{{ component.localizedName }}</h2>
-          <p class="text-sm text-slate-600 dark:text-slate-300">{{ component.localizedDescription }}</p>
+          <h2 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">{{ component.localizedName }}</h2>
+          <p class="text-sm text-surface-600 dark:text-surface-300">{{ component.localizedDescription }}</p>
         </div>
         <RouterLink
           :to="`/components/${component.id}`"
-          class="inline-flex items-center gap-2 self-start rounded-full bg-primary-500 px-4 py-2 text-sm font-medium text-white shadow-soft transition hover:bg-primary-400"
+          class="inline-flex items-center gap-2 self-start rounded-full bg-primary-500 px-4 py-2 text-sm font-medium text-primary-contrast shadow-soft transition hover:bg-primary-400"
         >
           {{ t('home.openPlayground') }}
           <i class="pi pi-arrow-right text-xs"></i>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import primeui from 'tailwindcss-primeui'
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
@@ -8,29 +10,10 @@ export default {
         sans: ['"Noto Sans KR"', 'Inter', 'ui-sans-serif', 'system-ui'],
         display: ['"Noto Sans KR"', 'Inter', 'ui-sans-serif', 'system-ui'],
       },
-      colors: {
-        primary: {
-          50: '#eef6ff',
-          100: '#dbeafe',
-          200: '#bfdbfe',
-          300: '#93c5fd',
-          400: '#60a5fa',
-          500: '#3b82f6',
-          600: '#2563eb',
-          700: '#1d4ed8',
-          800: '#1e40af',
-          900: '#1e3a8a',
-        },
-        surface: {
-          50: '#f8fafc',
-          100: '#f1f5f9',
-          900: '#0f172a',
-        },
-      },
       boxShadow: {
         soft: '0 20px 45px -20px rgba(15, 23, 42, 0.35)',
       },
     },
   },
-  plugins: [],
+  plugins: [primeui],
 }


### PR DESCRIPTION
## Summary
- add the tailwindcss-primeui plugin so Tailwind utilities reuse the PrimeVue palette
- align global layout, demos, and playground styling with PrimeVue surface and primary tokens
- update component defaults (spinner, overlay, QR) to rely on PrimeVue CSS variables for consistent coloring

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e186c5a8cc832ca4778a7618e440dc