### PR TITLE
Resolve component defaults dynamically

### DIFF
--- a/src/library/catalog.ts
+++ b/src/library/catalog.ts
@@ -27,7 +27,6 @@ export interface LabComponentDefinition {
   description: LocaleCopy
   component: ComponentLoader
   preview?: ComponentLoader
-  defaultProps: Record<string, PlaygroundPropValue>
   controls: ControlDefinition[]
 }
 
@@ -44,14 +43,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/Spinner.vue'),
     preview: () => import('@/demos/SpinnerDemo.vue'),
-    defaultProps: {
-      text: '',
-      size: 96,
-      thickness: 8,
-      textSize: 22,
-      indicatorColor: 'var(--p-primary-color)',
-      trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
-    },
     controls: [
       {
         key: 'text',
@@ -110,12 +101,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/QrCode.vue'),
     preview: () => import('@/demos/QrCodeDemo.vue'),
-    defaultProps: {
-      content: 'https://component-lab.dev/welcome',
-      lightColor: 'var(--p-surface-0)',
-      darkColor: 'var(--p-surface-900)',
-      icon: '',
-    },
     controls: [
       {
         key: 'content',
@@ -159,11 +144,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/BlurOverlay.vue'),
     preview: () => import('@/demos/BlurOverlayDemo.vue'),
-    defaultProps: {
-      visible: true,
-      blur: 7,
-      overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
-    },
     controls: [
       {
         key: 'visible',
@@ -201,17 +181,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/LoadingOverlay.vue'),
     preview: () => import('@/demos/LoadingOverlayDemo.vue'),
-    defaultProps: {
-      visible: false,
-      blur: 7,
-      description: '',
-      overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
-      spinnerSize: 48,
-      spinnerThickness: 4,
-      spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
-      spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
-      spinnerText: '',
-    },
     controls: [
       {
         key: 'visible',

--- a/src/views/ComponentPlayground.vue
+++ b/src/views/ComponentPlayground.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, reactive, watch } from 'vue'
+import {
+  computed,
+  createVNode,
+  defineAsyncComponent,
+  nextTick,
+  reactive,
+  render,
+  toRaw,
+  watch,
+} from 'vue'
 import type { AsyncComponentLoader } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -15,26 +24,114 @@ const { t, locale } = useI18n()
 
 const definition = computed<LabComponentDefinition | undefined>(() => getComponentDefinition(props.componentId))
 
-const cloneProps = (value: Record<string, PlaygroundPropValue>) =>
-  JSON.parse(JSON.stringify(value)) as Record<string, PlaygroundPropValue>
-
 const currentProps = reactive<Record<string, PlaygroundPropValue>>({})
+const defaultCache = new Map<string, Record<string, PlaygroundPropValue>>()
 
-const resetProps = () => {
-  if (!definition.value) {
+const normalizeColorValue = (value: PlaygroundPropValue): PlaygroundPropValue => {
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === '' || /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(trimmed)) {
+    return trimmed
+  }
+
+  const probe = document.createElement('div')
+  probe.style.position = 'absolute'
+  probe.style.pointerEvents = 'none'
+  probe.style.opacity = '0'
+  probe.style.color = trimmed
+  document.body.appendChild(probe)
+
+  const computedColor = getComputedStyle(probe).color
+  probe.remove()
+
+  const match =
+    computedColor &&
+    computedColor.match(/rgba?\((?<r>\d+),\s*(?<g>\d+),\s*(?<b>\d+)(?:,\s*(?<a>[0-9.]+))?\)/)
+
+  if (!match || !match.groups) {
+    return trimmed
+  }
+
+  const toHex = (component: number) => component.toString(16).padStart(2, '0')
+
+  const { r, g, b } = match.groups as { r: string; g: string; b: string }
+  const red = Number.parseInt(r, 10)
+  const green = Number.parseInt(g, 10)
+  const blue = Number.parseInt(b, 10)
+
+  return `#${toHex(red)}${toHex(green)}${toHex(blue)}`
+}
+
+const resolveComponentDefaults = async (definition: LabComponentDefinition) => {
+  const cached = defaultCache.get(definition.id)
+  if (cached) {
+    return { ...cached }
+  }
+
+  const loader = definition.component
+  const loaded = await loader()
+  const component = (loaded as any).default ?? loaded
+
+  const container = document.createElement('div')
+  container.style.position = 'absolute'
+  container.style.pointerEvents = 'none'
+  container.style.opacity = '0'
+  container.style.visibility = 'hidden'
+  document.body.appendChild(container)
+
+  const vnode = createVNode(component as any)
+  render(vnode, container)
+  await nextTick()
+
+  const instanceProps: Record<string, PlaygroundPropValue> = vnode.component?.props
+    ? { ...(toRaw(vnode.component.props) as Record<string, PlaygroundPropValue>) }
+    : {}
+
+  render(null, container)
+  container.remove()
+
+  const defaults: Record<string, PlaygroundPropValue> = {}
+
+  definition.controls.forEach((control) => {
+    const value = instanceProps[control.key]
+    if (control.type === 'color') {
+      defaults[control.key] = normalizeColorValue(value)
+    } else {
+      defaults[control.key] = value as PlaygroundPropValue
+    }
+  })
+
+  defaultCache.set(definition.id, { ...defaults })
+
+  return { ...defaults }
+}
+
+const applyDefaults = (defaults: Record<string, PlaygroundPropValue>) => {
+  Object.keys(currentProps).forEach((key) => delete currentProps[key])
+  Object.assign(currentProps, defaults)
+}
+
+const resetProps = async () => {
+  const activeDefinition = definition.value
+  if (!activeDefinition) {
+    Object.keys(currentProps).forEach((key) => delete currentProps[key])
     return
   }
 
-  const defaults = cloneProps(definition.value.defaultProps)
-  Object.keys(currentProps).forEach((key) => delete currentProps[key])
-  Object.assign(currentProps, defaults)
+  const defaults = await resolveComponentDefaults(activeDefinition)
+  applyDefaults(defaults)
 }
 
 watch(
   definition,
   (next) => {
     if (next) {
-      resetProps()
+      void resetProps()
+    } else {
+      Object.keys(currentProps).forEach((key) => delete currentProps[key])
     }
   },
   { immediate: true }


### PR DESCRIPTION
## Summary
- remove hard-coded default props from the component catalog entries
- derive playground defaults by rendering each component and normalizing color values for controls
- cache resolved defaults so resets stay in sync with component definitions
- remove extra safeguards around default normalization so the playground always reapplies computed values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1fad69a74832c9fd14fdba00cd509