### PR TITLE
Load playground defaults from components

### DIFF
--- a/src/components/library/BlurOverlay.vue
+++ b/src/components/library/BlurOverlay.vue
@@ -1,3 +1,13 @@
+<script lang="ts">
+export const blurOverlayDefaultProps = {
+  visible: true,
+  blur: 7,
+  overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
+}
+
+export const defaultProps = blurOverlayDefaultProps
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 
@@ -7,11 +17,7 @@ const props = withDefaults(
     blur?: number
     overlayColor?: string
   }>(),
-  {
-    visible: true,
-    blur: 7,
-    overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
-  }
+  blurOverlayDefaultProps
 )
 
 const overlayStyle = computed(() => ({

--- a/src/components/library/LoadingOverlay.vue
+++ b/src/components/library/LoadingOverlay.vue
@@ -1,3 +1,19 @@
+<script lang="ts">
+export const loadingOverlayDefaultProps = {
+  visible: false,
+  blur: 7,
+  description: '',
+  overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
+  spinnerSize: 48,
+  spinnerThickness: 4,
+  spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
+  spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
+  spinnerText: '',
+}
+
+export const defaultProps = loadingOverlayDefaultProps
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 import BlurOverlay from './BlurOverlay.vue'
@@ -15,17 +31,7 @@ const props = withDefaults(
     spinnerIndicatorColor?: string
     spinnerText?: string | number
   }>(),
-  {
-    visible: false,
-    blur: 7,
-    description: '',
-    overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
-    spinnerSize: 48,
-    spinnerThickness: 4,
-    spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
-    spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
-    spinnerText: '',
-  }
+  loadingOverlayDefaultProps
 )
 
 const hasDescription = computed(() => Boolean(props.description?.trim()))

--- a/src/components/library/QrCode.vue
+++ b/src/components/library/QrCode.vue
@@ -1,3 +1,14 @@
+<script lang="ts">
+export const qrCodeDefaultProps = {
+  content: 'https://component-lab.dev/welcome',
+  lightColor: 'var(--p-surface-0)',
+  darkColor: 'var(--p-surface-900)',
+  icon: '',
+}
+
+export const defaultProps = qrCodeDefaultProps
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 import QrcodeVue from 'qrcode.vue'
@@ -9,11 +20,7 @@ const props = withDefaults(
     darkColor?: string
     icon?: string
   }>(),
-  {
-    lightColor: 'var(--p-surface-0)',
-    darkColor: 'var(--p-surface-900)',
-    icon: '',
-  }
+  qrCodeDefaultProps
 )
 
 const hasIcon = computed(() => Boolean(props.icon?.trim()))

--- a/src/components/library/Spinner.vue
+++ b/src/components/library/Spinner.vue
@@ -1,3 +1,16 @@
+<script lang="ts">
+export const spinnerDefaultProps = {
+  text: '',
+  size: 96,
+  thickness: 8,
+  textSize: 22,
+  trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
+  indicatorColor: 'var(--p-primary-color)',
+}
+
+export const defaultProps = spinnerDefaultProps
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 
@@ -10,14 +23,7 @@ const props = withDefaults(
     trackColor?: string
     indicatorColor?: string
   }>(),
-  {
-    text: '',
-    size: 96,
-    thickness: 8,
-    textSize: 22,
-    trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
-    indicatorColor: 'var(--p-primary-color)',
-  }
+  spinnerDefaultProps
 )
 
 const displayText = computed(() => `${props.text ?? ''}`)

--- a/src/library/catalog.ts
+++ b/src/library/catalog.ts
@@ -27,7 +27,7 @@ export interface LabComponentDefinition {
   description: LocaleCopy
   component: ComponentLoader
   preview?: ComponentLoader
-  defaultProps: Record<string, PlaygroundPropValue>
+  loadDefaultProps: () => Promise<Record<string, PlaygroundPropValue>>
   controls: ControlDefinition[]
 }
 
@@ -44,14 +44,7 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/Spinner.vue'),
     preview: () => import('@/demos/SpinnerDemo.vue'),
-    defaultProps: {
-      text: '',
-      size: 96,
-      thickness: 8,
-      textSize: 22,
-      indicatorColor: 'var(--p-primary-color)',
-      trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
-    },
+    loadDefaultProps: async () => (await import('@/components/library/Spinner.vue')).defaultProps ?? {},
     controls: [
       {
         key: 'text',
@@ -110,12 +103,7 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/QrCode.vue'),
     preview: () => import('@/demos/QrCodeDemo.vue'),
-    defaultProps: {
-      content: 'https://component-lab.dev/welcome',
-      lightColor: 'var(--p-surface-0)',
-      darkColor: 'var(--p-surface-900)',
-      icon: '',
-    },
+    loadDefaultProps: async () => (await import('@/components/library/QrCode.vue')).defaultProps ?? {},
     controls: [
       {
         key: 'content',
@@ -159,11 +147,7 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/BlurOverlay.vue'),
     preview: () => import('@/demos/BlurOverlayDemo.vue'),
-    defaultProps: {
-      visible: true,
-      blur: 7,
-      overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
-    },
+    loadDefaultProps: async () => (await import('@/components/library/BlurOverlay.vue')).defaultProps ?? {},
     controls: [
       {
         key: 'visible',
@@ -201,17 +185,7 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/LoadingOverlay.vue'),
     preview: () => import('@/demos/LoadingOverlayDemo.vue'),
-    defaultProps: {
-      visible: false,
-      blur: 7,
-      description: '',
-      overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
-      spinnerSize: 48,
-      spinnerThickness: 4,
-      spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
-      spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
-      spinnerText: '',
-    },
+    loadDefaultProps: async () => (await import('@/components/library/LoadingOverlay.vue')).defaultProps ?? {},
     controls: [
       {
         key: 'visible',

--- a/src/views/ComponentPlayground.vue
+++ b/src/views/ComponentPlayground.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, reactive, watch } from 'vue'
-import type { AsyncComponentLoader } from 'vue'
+import { computed, defineAsyncComponent, nextTick, reactive, watch, watchEffect } from 'vue'
+import type { AsyncComponentLoader, ComponentPublicInstance } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElColorPicker } from 'element-plus'
@@ -20,26 +20,141 @@ const cloneProps = (value: Record<string, PlaygroundPropValue>) =>
   JSON.parse(JSON.stringify(value)) as Record<string, PlaygroundPropValue>
 
 const currentProps = reactive<Record<string, PlaygroundPropValue>>({})
+const colorPickerValues = reactive<Record<string, string>>({})
+const colorInputRefs: Record<string, HTMLInputElement | null> = {}
 
-const resetProps = () => {
-  if (!definition.value) {
+const clearCurrentProps = () => {
+  Object.keys(currentProps).forEach((key) => delete currentProps[key])
+}
+
+const clearColorState = () => {
+  Object.keys(colorPickerValues).forEach((key) => delete colorPickerValues[key])
+  Object.keys(colorInputRefs).forEach((key) => delete colorInputRefs[key])
+}
+
+const defaultPropsCache = new Map<string, Record<string, PlaygroundPropValue>>()
+
+const getCachedDefaults = async (component: LabComponentDefinition) => {
+  let cached = defaultPropsCache.get(component.id)
+  if (!cached) {
+    const loaded = (await component.loadDefaultProps()) ?? {}
+    cached = cloneProps(loaded)
+    defaultPropsCache.set(component.id, cached)
+  }
+  return cloneProps(cached)
+}
+
+const applyProps = (props: Record<string, PlaygroundPropValue>) => {
+  clearCurrentProps()
+  Object.assign(currentProps, props)
+}
+
+const syncColorControl = (key: string) => {
+  const rawValue = currentProps[key]
+  const input = colorInputRefs[key]
+
+  if (typeof rawValue !== 'string' || !rawValue.trim()) {
+    if (input) {
+      input.style.color = ''
+    }
+    colorPickerValues[key] = ''
     return
   }
 
-  const defaults = cloneProps(definition.value.defaultProps)
-  Object.keys(currentProps).forEach((key) => delete currentProps[key])
-  Object.assign(currentProps, defaults)
+  if (!input) {
+    colorPickerValues[key] = rawValue
+    return
+  }
+
+  input.style.color = ''
+  input.style.color = rawValue
+  const resolved = getComputedStyle(input).color
+  colorPickerValues[key] = resolved
+  input.style.color = resolved
+}
+
+const bindColorInput = (key: string) => (el: Element | ComponentPublicInstance | null) => {
+  const input = el instanceof HTMLInputElement ? el : null
+
+  if (input) {
+    colorInputRefs[key] = input
+    void nextTick(() => syncColorControl(key))
+    return
+  }
+
+  delete colorInputRefs[key]
+}
+
+const updateColorProp = (key: string, value: string | null) => {
+  currentProps[key] = value ?? ''
+}
+
+const onColorPickerChange = (key: string, value: string | null) => {
+  updateColorProp(key, value)
+}
+
+const onColorPickerActiveChange = (key: string, value: string | null) => {
+  updateColorProp(key, value)
+}
+
+let activeLoadToken = 0
+
+const resetProps = async () => {
+  if (!definition.value) {
+    clearCurrentProps()
+    clearColorState()
+    return
+  }
+
+  const defaults = await getCachedDefaults(definition.value)
+  applyProps(defaults)
+  await nextTick()
+  definition.value.controls
+    .filter((control) => control.type === 'color')
+    .forEach((control) => syncColorControl(control.key))
 }
 
 watch(
   definition,
   (next) => {
-    if (next) {
-      resetProps()
+    const loadToken = ++activeLoadToken
+    if (!next) {
+      clearCurrentProps()
+      clearColorState()
+      return
     }
+
+    clearColorState()
+
+    void (async () => {
+      const defaults = await getCachedDefaults(next)
+      if (loadToken !== activeLoadToken) {
+        return
+      }
+      applyProps(defaults)
+      await nextTick()
+      next.controls
+        .filter((control) => control.type === 'color')
+        .forEach((control) => syncColorControl(control.key))
+    })()
   },
   { immediate: true }
 )
+
+watchEffect(() => {
+  const component = definition.value
+  if (!component) {
+    return
+  }
+
+  component.controls
+    .filter((control) => control.type === 'color')
+    .forEach((control) => {
+      // Access the reactive value so Vue tracks the dependency
+      void currentProps[control.key]
+      void nextTick(() => syncColorControl(control.key))
+    })
+})
 
 const activeLocale = computed(() => locale.value as SupportedLocale)
 
@@ -123,7 +238,7 @@ watch(
         >
           <label
             v-if="control.type !== 'boolean'"
-            :for="control.key"
+            :for="control.type === 'color' ? `${control.key}-input` : control.key"
             class="font-medium text-surface-700 dark:text-surface-200"
           >
             {{ localize(control.label) }}
@@ -145,13 +260,25 @@ watch(
             ></textarea>
           </template>
           <template v-else-if="control.type === 'color'">
-            <ElColorPicker
-              :id="control.key"
-              v-model="(currentProps[control.key] as string | undefined)"
-              show-alpha
-              color-format="rgb"
-              class="w-full"
-            />
+            <div class="flex items-center gap-3">
+              <ElColorPicker
+                :id="control.key"
+                :model-value="colorPickerValues[control.key] ?? ''"
+                show-alpha
+                color-format="rgb"
+                class="flex-shrink-0"
+                @change="onColorPickerChange(control.key, $event)"
+                @active-change="onColorPickerActiveChange(control.key, $event)"
+              />
+              <input
+                :id="`${control.key}-input`"
+                v-model="(currentProps[control.key] as string | undefined)"
+                type="text"
+                class="w-full rounded-xl border border-surface-200/70 bg-surface-0 px-3 py-2 text-sm shadow-sm transition focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:border-surface-700/70 dark:bg-surface-900 dark:text-surface-0 dark:focus:border-primary-300"
+                :style="{ color: colorPickerValues[control.key] ?? '' }"
+                :ref="bindColorInput(control.key)"
+              />
+            </div>
           </template>
           <template v-else-if="control.type === 'slider'">
             <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- load component playground defaults by importing each component's exported default props
- export shared default prop objects from library components so the catalog and playground stay aligned
- pair the color picker with a text input and synchronize their values via computed styles in the playground controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2158ae138832c9aa0bcc56a53f5bb