### PR TITLE
feat: derive playground defaults from component exports

### DIFF
--- a/src/components/library/BlurOverlay.vue
+++ b/src/components/library/BlurOverlay.vue
@@ -1,3 +1,11 @@
+<script lang="ts">
+export const blurOverlayDefaultProps = {
+  visible: true,
+  blur: 7,
+  overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
+} as const
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 
@@ -7,11 +15,7 @@ const props = withDefaults(
     blur?: number
     overlayColor?: string
   }>(),
-  {
-    visible: true,
-    blur: 7,
-    overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
-  }
+  blurOverlayDefaultProps
 )
 
 const overlayStyle = computed(() => ({

--- a/src/components/library/LoadingOverlay.vue
+++ b/src/components/library/LoadingOverlay.vue
@@ -1,3 +1,17 @@
+<script lang="ts">
+export const loadingOverlayDefaultProps = {
+  visible: false,
+  blur: 7,
+  description: '',
+  overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
+  spinnerSize: 48,
+  spinnerThickness: 4,
+  spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
+  spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
+  spinnerText: '',
+} as const
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 import BlurOverlay from './BlurOverlay.vue'
@@ -15,17 +29,7 @@ const props = withDefaults(
     spinnerIndicatorColor?: string
     spinnerText?: string | number
   }>(),
-  {
-    visible: false,
-    blur: 7,
-    description: '',
-    overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
-    spinnerSize: 48,
-    spinnerThickness: 4,
-    spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
-    spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
-    spinnerText: '',
-  }
+  loadingOverlayDefaultProps
 )
 
 const hasDescription = computed(() => Boolean(props.description?.trim()))

--- a/src/components/library/QrCode.vue
+++ b/src/components/library/QrCode.vue
@@ -1,19 +1,24 @@
+<script lang="ts">
+export const qrCodeDefaultProps = {
+  content: 'https://component-lab.dev/welcome',
+  lightColor: 'var(--p-surface-0)',
+  darkColor: 'var(--p-surface-900)',
+  icon: '',
+} as const
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 import QrcodeVue from 'qrcode.vue'
 
 const props = withDefaults(
   defineProps<{
-    content: string
+    content?: string
     lightColor?: string
     darkColor?: string
     icon?: string
   }>(),
-  {
-    lightColor: 'var(--p-surface-0)',
-    darkColor: 'var(--p-surface-900)',
-    icon: '',
-  }
+  qrCodeDefaultProps
 )
 
 const hasIcon = computed(() => Boolean(props.icon?.trim()))

--- a/src/components/library/Spinner.vue
+++ b/src/components/library/Spinner.vue
@@ -1,3 +1,14 @@
+<script lang="ts">
+export const spinnerDefaultProps = {
+  text: '',
+  size: 96,
+  thickness: 8,
+  textSize: 22,
+  trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
+  indicatorColor: 'var(--p-primary-color)',
+} as const
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 
@@ -10,14 +21,7 @@ const props = withDefaults(
     trackColor?: string
     indicatorColor?: string
   }>(),
-  {
-    text: '',
-    size: 96,
-    thickness: 8,
-    textSize: 22,
-    trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
-    indicatorColor: 'var(--p-primary-color)',
-  }
+  spinnerDefaultProps
 )
 
 const displayText = computed(() => `${props.text ?? ''}`)

--- a/src/library/catalog.ts
+++ b/src/library/catalog.ts
@@ -1,5 +1,7 @@
 import type { AsyncComponentLoader } from 'vue'
 
+export type PlaygroundPropRecord = Record<string, PlaygroundPropValue>
+
 export type LocaleCopy = {
   en: string
   ko: string
@@ -27,7 +29,6 @@ export interface LabComponentDefinition {
   description: LocaleCopy
   component: ComponentLoader
   preview?: ComponentLoader
-  defaultProps: Record<string, PlaygroundPropValue>
   controls: ControlDefinition[]
 }
 
@@ -44,14 +45,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/Spinner.vue'),
     preview: () => import('@/demos/SpinnerDemo.vue'),
-    defaultProps: {
-      text: '',
-      size: 96,
-      thickness: 8,
-      textSize: 22,
-      indicatorColor: 'var(--p-primary-color)',
-      trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
-    },
     controls: [
       {
         key: 'text',
@@ -110,12 +103,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/QrCode.vue'),
     preview: () => import('@/demos/QrCodeDemo.vue'),
-    defaultProps: {
-      content: 'https://component-lab.dev/welcome',
-      lightColor: 'var(--p-surface-0)',
-      darkColor: 'var(--p-surface-900)',
-      icon: '',
-    },
     controls: [
       {
         key: 'content',
@@ -159,11 +146,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/BlurOverlay.vue'),
     preview: () => import('@/demos/BlurOverlayDemo.vue'),
-    defaultProps: {
-      visible: true,
-      blur: 7,
-      overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
-    },
     controls: [
       {
         key: 'visible',
@@ -201,17 +183,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/LoadingOverlay.vue'),
     preview: () => import('@/demos/LoadingOverlayDemo.vue'),
-    defaultProps: {
-      visible: false,
-      blur: 7,
-      description: '',
-      overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
-      spinnerSize: 48,
-      spinnerThickness: 4,
-      spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
-      spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
-      spinnerText: '',
-    },
     controls: [
       {
         key: 'visible',
@@ -286,3 +257,49 @@ export const componentCatalog: LabComponentDefinition[] = [
 export const componentMap = new Map(componentCatalog.map((item) => [item.id, item]))
 
 export const getComponentDefinition = (id: string) => componentMap.get(id)
+
+type ComponentDefaultsLoader = () => Promise<PlaygroundPropRecord>
+
+const componentDefaultLoaders = new Map<string, ComponentDefaultsLoader>([
+  [
+    'spinner',
+    async () => {
+      const module = await import('@/components/library/Spinner.vue')
+      return module.spinnerDefaultProps as PlaygroundPropRecord
+    },
+  ],
+  [
+    'qr-code',
+    async () => {
+      const module = await import('@/components/library/QrCode.vue')
+      return module.qrCodeDefaultProps as PlaygroundPropRecord
+    },
+  ],
+  [
+    'blur-overlay',
+    async () => {
+      const module = await import('@/components/library/BlurOverlay.vue')
+      return module.blurOverlayDefaultProps as PlaygroundPropRecord
+    },
+  ],
+  [
+    'loading-overlay',
+    async () => {
+      const module = await import('@/components/library/LoadingOverlay.vue')
+      return module.loadingOverlayDefaultProps as PlaygroundPropRecord
+    },
+  ],
+])
+
+const cloneProps = (value: PlaygroundPropRecord | undefined) =>
+  value ? (JSON.parse(JSON.stringify(value)) as PlaygroundPropRecord) : {}
+
+export const loadComponentDefaultProps = async (id: string) => {
+  const loader = componentDefaultLoaders.get(id)
+  if (!loader) {
+    return {}
+  }
+
+  const defaults = await loader()
+  return cloneProps(defaults)
+}

--- a/src/views/ComponentPlayground.vue
+++ b/src/views/ComponentPlayground.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, reactive, watch } from 'vue'
-import type { AsyncComponentLoader } from 'vue'
+import { computed, defineAsyncComponent, nextTick, reactive, watch } from 'vue'
+import type { AsyncComponentLoader, ComponentPublicInstance } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElColorPicker } from 'element-plus'
 import type { LabComponentDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/catalog'
-import { getComponentDefinition } from '@/library/catalog'
+import { getComponentDefinition, loadComponentDefaultProps } from '@/library/catalog'
 import type { SupportedLocale } from '@/i18n'
 
 const props = defineProps<{
@@ -16,26 +16,88 @@ const { t, locale } = useI18n()
 
 const definition = computed<LabComponentDefinition | undefined>(() => getComponentDefinition(props.componentId))
 
-const cloneProps = (value: Record<string, PlaygroundPropValue>) =>
-  JSON.parse(JSON.stringify(value)) as Record<string, PlaygroundPropValue>
-
 const currentProps = reactive<Record<string, PlaygroundPropValue>>({})
+const colorPickerValues = reactive<Record<string, string>>({})
+const colorSampleRefs = new Map<string, HTMLElement>()
 
-const resetProps = () => {
+const syncColorPickerForKey = (key: string) => {
+  const sample = colorSampleRefs.get(key)
+  if (!sample) {
+    return
+  }
+
+  const rawValue = (currentProps[key] as string | undefined) ?? ''
+
+  if (!rawValue) {
+    sample.style.color = 'transparent'
+    colorPickerValues[key] = ''
+    return
+  }
+
+  sample.style.color = rawValue
+  const computedColor = getComputedStyle(sample).color
+  colorPickerValues[key] = computedColor
+}
+
+const syncAllColorPickers = () => {
   if (!definition.value) {
     return
   }
 
-  const defaults = cloneProps(definition.value.defaultProps)
+  for (const control of definition.value.controls) {
+    if (control.type === 'color') {
+      syncColorPickerForKey(control.key)
+    }
+  }
+}
+
+const setColorSampleRef = (key: string) => (el: Element | ComponentPublicInstance | null) => {
+  if (el instanceof HTMLElement) {
+    colorSampleRefs.set(key, el)
+    syncColorPickerForKey(key)
+  } else {
+    colorSampleRefs.delete(key)
+  }
+}
+
+const handleColorInput = (key: string, event: Event) => {
+  const target = event.target as HTMLInputElement | null
+  if (target) {
+    currentProps[key] = target.value
+  }
+  syncColorPickerForKey(key)
+}
+
+const handleColorPickerChange = (key: string, value: string | null) => {
+  const normalized = value ?? ''
+  colorPickerValues[key] = normalized
+  currentProps[key] = normalized
+  void nextTick(() => {
+    syncColorPickerForKey(key)
+  })
+}
+
+const resetProps = async () => {
+  if (!definition.value) {
+    return
+  }
+
+  const defaults = await loadComponentDefaultProps(definition.value.id)
   Object.keys(currentProps).forEach((key) => delete currentProps[key])
   Object.assign(currentProps, defaults)
+  Object.keys(colorPickerValues).forEach((key) => delete colorPickerValues[key])
+  await nextTick()
+  syncAllColorPickers()
 }
 
 watch(
   definition,
   (next) => {
     if (next) {
-      resetProps()
+      void resetProps()
+    } else {
+      Object.keys(currentProps).forEach((key) => delete currentProps[key])
+      Object.keys(colorPickerValues).forEach((key) => delete colorPickerValues[key])
     }
   },
   { immediate: true }
@@ -109,7 +171,7 @@ watch(
         <button
           type="button"
           class="text-xs font-semibold text-primary-500 transition hover:text-primary-400"
-          @click="resetProps"
+          @click="resetProps()"
         >
           {{ t('playground.reset') }}
         </button>
@@ -145,13 +207,25 @@ watch(
             ></textarea>
           </template>
           <template v-else-if="control.type === 'color'">
-            <ElColorPicker
-              :id="control.key"
-              v-model="(currentProps[control.key] as string | undefined)"
-              show-alpha
-              color-format="rgb"
-              class="w-full"
-            />
+            <div class="flex items-center gap-3">
+              <ElColorPicker
+                :id="`${control.key}-picker`"
+                :model-value="colorPickerValues[control.key] ?? ''"
+                show-alpha
+                color-format="rgb"
+                class="w-12 shrink-0"
+                :aria-label="localize(control.label)"
+                @update:model-value="(value: string | null) => handleColorPickerChange(control.key, value)"
+              />
+              <input
+                :id="control.key"
+                v-model="(currentProps[control.key] as string | undefined)"
+                type="text"
+                class="w-full rounded-xl border border-surface-200/70 bg-surface-0 px-3 py-2 text-sm text-surface-700 shadow-sm transition focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:border-surface-700/70 dark:bg-surface-900 dark:text-surface-0 dark:focus:border-primary-300"
+                @input="handleColorInput(control.key, $event)"
+              />
+            </div>
+            <span :ref="setColorSampleRef(control.key)" class="sr-only" aria-hidden="true"></span>
           </template>
           <template v-else-if="control.type === 'slider'">
             <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- dynamically import default props from each component instead of duplicating them in the catalog
- expose default prop constants from the library components for reuse in the playground
- enhance the playground color controls with synchronized text inputs and reset handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2158ae138832c9aa0bcc56a53f5bb