### PR TITLE
Load playground defaults from component exports

### DIFF
--- a/src/components/library/BlurOverlay.vue
+++ b/src/components/library/BlurOverlay.vue
@@ -1,3 +1,11 @@
+<script lang="ts">
+export const defaultProps = {
+  visible: true,
+  blur: 7,
+  overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
+} as const
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 
@@ -7,11 +15,7 @@ const props = withDefaults(
     blur?: number
     overlayColor?: string
   }>(),
-  {
-    visible: true,
-    blur: 7,
-    overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
-  }
+  defaultProps
 )
 
 const overlayStyle = computed(() => ({

--- a/src/components/library/LoadingOverlay.vue
+++ b/src/components/library/LoadingOverlay.vue
@@ -1,3 +1,17 @@
+<script lang="ts">
+export const defaultProps = {
+  visible: false,
+  blur: 7,
+  description: '',
+  overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
+  spinnerSize: 48,
+  spinnerThickness: 4,
+  spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
+  spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
+  spinnerText: '',
+} as const
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 import BlurOverlay from './BlurOverlay.vue'
@@ -15,17 +29,7 @@ const props = withDefaults(
     spinnerIndicatorColor?: string
     spinnerText?: string | number
   }>(),
-  {
-    visible: false,
-    blur: 7,
-    description: '',
-    overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
-    spinnerSize: 48,
-    spinnerThickness: 4,
-    spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
-    spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
-    spinnerText: '',
-  }
+  defaultProps
 )
 
 const hasDescription = computed(() => Boolean(props.description?.trim()))

--- a/src/components/library/QrCode.vue
+++ b/src/components/library/QrCode.vue
@@ -1,3 +1,11 @@
+<script lang="ts">
+export const defaultProps = {
+  lightColor: 'var(--p-surface-0)',
+  darkColor: 'var(--p-surface-900)',
+  icon: '',
+} as const
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 import QrcodeVue from 'qrcode.vue'
@@ -9,11 +17,7 @@ const props = withDefaults(
     darkColor?: string
     icon?: string
   }>(),
-  {
-    lightColor: 'var(--p-surface-0)',
-    darkColor: 'var(--p-surface-900)',
-    icon: '',
-  }
+  defaultProps
 )
 
 const hasIcon = computed(() => Boolean(props.icon?.trim()))

--- a/src/components/library/Spinner.vue
+++ b/src/components/library/Spinner.vue
@@ -1,3 +1,14 @@
+<script lang="ts">
+export const defaultProps = {
+  text: '',
+  size: 96,
+  thickness: 8,
+  textSize: 22,
+  trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
+  indicatorColor: 'var(--p-primary-color)',
+} as const
+</script>
+
 <script setup lang="ts">
 import { computed } from 'vue'
 
@@ -10,14 +21,7 @@ const props = withDefaults(
     trackColor?: string
     indicatorColor?: string
   }>(),
-  {
-    text: '',
-    size: 96,
-    thickness: 8,
-    textSize: 22,
-    trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
-    indicatorColor: 'var(--p-primary-color)',
-  }
+  defaultProps
 )
 
 const displayText = computed(() => `${props.text ?? ''}`)

--- a/src/library/catalog.ts
+++ b/src/library/catalog.ts
@@ -27,7 +27,6 @@ export interface LabComponentDefinition {
   description: LocaleCopy
   component: ComponentLoader
   preview?: ComponentLoader
-  defaultProps: Record<string, PlaygroundPropValue>
   controls: ControlDefinition[]
 }
 
@@ -44,14 +43,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/Spinner.vue'),
     preview: () => import('@/demos/SpinnerDemo.vue'),
-    defaultProps: {
-      text: '',
-      size: 96,
-      thickness: 8,
-      textSize: 22,
-      indicatorColor: 'var(--p-primary-color)',
-      trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
-    },
     controls: [
       {
         key: 'text',
@@ -110,12 +101,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/QrCode.vue'),
     preview: () => import('@/demos/QrCodeDemo.vue'),
-    defaultProps: {
-      content: 'https://component-lab.dev/welcome',
-      lightColor: 'var(--p-surface-0)',
-      darkColor: 'var(--p-surface-900)',
-      icon: '',
-    },
     controls: [
       {
         key: 'content',
@@ -159,11 +144,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/BlurOverlay.vue'),
     preview: () => import('@/demos/BlurOverlayDemo.vue'),
-    defaultProps: {
-      visible: true,
-      blur: 7,
-      overlayColor: 'color-mix(in srgb, var(--p-surface-900) 45%, transparent)',
-    },
     controls: [
       {
         key: 'visible',
@@ -201,17 +181,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@/components/library/LoadingOverlay.vue'),
     preview: () => import('@/demos/LoadingOverlayDemo.vue'),
-    defaultProps: {
-      visible: false,
-      blur: 7,
-      description: '',
-      overlayColor: 'color-mix(in srgb, var(--p-surface-900) 55%, transparent)',
-      spinnerSize: 48,
-      spinnerThickness: 4,
-      spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
-      spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
-      spinnerText: '',
-    },
     controls: [
       {
         key: 'visible',

--- a/src/views/ComponentPlayground.vue
+++ b/src/views/ComponentPlayground.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, reactive, watch } from 'vue'
-import type { AsyncComponentLoader } from 'vue'
+import { computed, defineAsyncComponent, reactive, ref, watch } from 'vue'
+import type { AsyncComponentLoader, WatchStopHandle } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElColorPicker } from 'element-plus'
@@ -16,30 +16,116 @@ const { t, locale } = useI18n()
 
 const definition = computed<LabComponentDefinition | undefined>(() => getComponentDefinition(props.componentId))
 
-const cloneProps = (value: Record<string, PlaygroundPropValue>) =>
-  JSON.parse(JSON.stringify(value)) as Record<string, PlaygroundPropValue>
+const cloneProps = (value?: Record<string, PlaygroundPropValue>) =>
+  value ? (JSON.parse(JSON.stringify(value)) as Record<string, PlaygroundPropValue>) : {}
 
+const componentDefaults = ref<Record<string, PlaygroundPropValue>>({})
 const currentProps = reactive<Record<string, PlaygroundPropValue>>({})
+const resolvedColors = reactive<Record<string, string>>({})
+const colorResolver = ref<HTMLElement | null>(null)
 
-const resetProps = () => {
+const colorKeys = computed(() =>
+  definition.value?.controls
+    .filter((control) => control.type === 'color')
+    .map((control) => control.key) ?? []
+)
+
+const applyDefaults = (defaults: Record<string, PlaygroundPropValue>) => {
+  const clonedDefaults = cloneProps(defaults)
+  Object.keys(currentProps).forEach((key) => delete currentProps[key])
+  Object.keys(resolvedColors).forEach((key) => delete resolvedColors[key])
+  Object.assign(currentProps, clonedDefaults)
+}
+
+const loadComponentDefaults = async () => {
   if (!definition.value) {
+    componentDefaults.value = {}
+    Object.keys(currentProps).forEach((key) => delete currentProps[key])
+    Object.keys(resolvedColors).forEach((key) => delete resolvedColors[key])
     return
   }
 
-  const defaults = cloneProps(definition.value.defaultProps)
-  Object.keys(currentProps).forEach((key) => delete currentProps[key])
-  Object.assign(currentProps, defaults)
+  const targetId = definition.value.id
+  const module = await definition.value.component()
+  if (definition.value?.id !== targetId) {
+    return
+  }
+
+  const defaults = cloneProps((module as { defaultProps?: Record<string, PlaygroundPropValue> }).defaultProps)
+  componentDefaults.value = defaults
+  applyDefaults(defaults)
 }
 
 watch(
   definition,
-  (next) => {
-    if (next) {
-      resetProps()
-    }
+  () => {
+    void loadComponentDefaults()
   },
   { immediate: true }
 )
+
+const resetProps = () => {
+  applyDefaults(componentDefaults.value)
+}
+
+const resolveColorValue = (value: string | undefined) => {
+  if (!value) {
+    return ''
+  }
+
+  const resolver = colorResolver.value
+  if (!resolver) {
+    return value
+  }
+
+  resolver.style.color = ''
+  resolver.style.color = value
+  return getComputedStyle(resolver).color
+}
+
+const updateResolvedColor = (key: string, value: string | undefined) => {
+  resolvedColors[key] = resolveColorValue(typeof value === 'string' ? value : undefined)
+}
+
+watch(colorResolver, (resolver) => {
+  if (!resolver) {
+    return
+  }
+
+  colorKeys.value.forEach((key) => {
+    updateResolvedColor(key, currentProps[key] as string | undefined)
+  })
+})
+
+watch(
+  colorKeys,
+  (keys, _prevKeys, onCleanup) => {
+    const trackedKeys = [...keys]
+    const stops: WatchStopHandle[] = trackedKeys.map((key) =>
+      watch(
+        () => currentProps[key] as string | undefined,
+        (value) => {
+          updateResolvedColor(key, value)
+        },
+        { immediate: true }
+      )
+    )
+
+    onCleanup(() => {
+      stops.forEach((stop) => stop())
+      trackedKeys.forEach((key) => {
+        if (!colorKeys.value.includes(key)) {
+          delete resolvedColors[key]
+        }
+      })
+    })
+  },
+  { immediate: true }
+)
+
+const handleColorPickerChange = (key: string, value: string | null) => {
+  currentProps[key] = (value ?? '') as PlaygroundPropValue
+}
 
 const activeLocale = computed(() => locale.value as SupportedLocale)
 
@@ -145,13 +231,21 @@ watch(
             ></textarea>
           </template>
           <template v-else-if="control.type === 'color'">
-            <ElColorPicker
-              :id="control.key"
-              v-model="(currentProps[control.key] as string | undefined)"
-              show-alpha
-              color-format="rgb"
-              class="w-full"
-            />
+            <div class="flex items-center gap-3">
+              <ElColorPicker
+                :model-value="resolvedColors[control.key] ?? ''"
+                show-alpha
+                color-format="rgb"
+                class="shrink-0"
+                @update:model-value="handleColorPickerChange(control.key, $event)"
+              />
+              <input
+                :id="control.key"
+                v-model="(currentProps[control.key] as string | undefined)"
+                type="text"
+                class="flex-1 rounded-xl border border-surface-200/70 bg-surface-0 px-3 py-2 text-sm text-surface-700 shadow-sm transition focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-100 dark:border-surface-700/70 dark:bg-surface-900 dark:text-surface-0 dark:focus:border-primary-300"
+              />
+            </div>
           </template>
           <template v-else-if="control.type === 'slider'">
             <div class="flex items-center gap-3">
@@ -183,6 +277,11 @@ watch(
           </p>
         </div>
       </form>
+      <span
+        ref="colorResolver"
+        aria-hidden="true"
+        style="position: fixed; width: 0; height: 0; opacity: 0; pointer-events: none"
+      ></span>
     </aside>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- export each library component's default props so the playground can reuse them directly
- remove duplicated default prop data from the catalog and load it dynamically when a component changes
- show both a color picker and synchronized text input for color controls so custom CSS values stay in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2158ae138832c9aa0bcc56a53f5bb