### PR TITLE
Fix color picker alpha binding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "component-lab",
       "version": "0.1.0",
       "dependencies": {
+        "@ctrl/tinycolor": "^3.6.1",
         "@element-plus/icons-vue": "^2.3.2",
         "@primevue/themes": "^4.4.0",
         "element-plus": "^2.11.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.2",
+    "@ctrl/tinycolor": "^3.6.1",
     "@primevue/themes": "^4.4.0",
     "element-plus": "^2.11.4",
     "primeicons": "^7.0.0",

--- a/src/views/ComponentPlayground.vue
+++ b/src/views/ComponentPlayground.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, defineAsyncComponent, reactive, ref, watch } from 'vue'
+import { TinyColor } from '@ctrl/tinycolor'
 import type { AsyncComponentLoader, WatchStopHandle } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -68,6 +69,15 @@ const resetProps = () => {
   applyDefaults(componentDefaults.value)
 }
 
+const normalizeResolvedColor = (value: string) => {
+  if (!value) {
+    return ''
+  }
+
+  const color = new TinyColor(value)
+  return color.isValid ? color.toRgbString() : value
+}
+
 const resolveColorValue = (value: string | undefined) => {
   if (!value) {
     return ''
@@ -75,12 +85,12 @@ const resolveColorValue = (value: string | undefined) => {
 
   const resolver = colorResolver.value
   if (!resolver) {
-    return value
+    return normalizeResolvedColor(value)
   }
 
   resolver.style.color = ''
   resolver.style.color = value
-  return getComputedStyle(resolver).color
+  return normalizeResolvedColor(getComputedStyle(resolver).color)
 }
 
 const updateResolvedColor = (key: string, value: string | undefined) => {


### PR DESCRIPTION
## Summary
- normalize resolved colors before binding them to the Element Plus color picker so alpha values are preserved
- add @ctrl/tinycolor as a direct dependency to support color normalization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e21e539334832cbeddfe4da90ce86c