### PR TITLE
Normalize computed colors for spinner playground

### DIFF
--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,161 @@
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1)
+
+const formatAlpha = (alpha: number) => {
+  const normalized = clamp01(alpha)
+  if (normalized >= 1) {
+    return null
+  }
+  const rounded = Math.round(normalized * 1000) / 1000
+  return `${rounded}`
+}
+
+const formatRgbString = (r: number, g: number, b: number, alpha = 1) => {
+  const red = Math.round(clamp01(r) * 255)
+  const green = Math.round(clamp01(g) * 255)
+  const blue = Math.round(clamp01(b) * 255)
+  const alphaString = formatAlpha(alpha)
+
+  if (alphaString === null) {
+    return `rgb(${red}, ${green}, ${blue})`
+  }
+
+  return `rgba(${red}, ${green}, ${blue}, ${alphaString})`
+}
+
+const parseUnitValue = (value: string) => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return Number.NaN
+  }
+
+  if (trimmed === 'none') {
+    return 0
+  }
+
+  if (trimmed.endsWith('%')) {
+    return clamp01(Number.parseFloat(trimmed.slice(0, -1)) / 100)
+  }
+
+  const numeric = Number.parseFloat(trimmed)
+  if (Number.isNaN(numeric)) {
+    return Number.NaN
+  }
+
+  if (numeric > 1) {
+    return clamp01(numeric / 255)
+  }
+
+  return clamp01(numeric)
+}
+
+const parseAlphaValue = (value: string | undefined) => {
+  if (!value) {
+    return 1
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return 1
+  }
+
+  if (trimmed.endsWith('%')) {
+    return clamp01(Number.parseFloat(trimmed.slice(0, -1)) / 100)
+  }
+
+  const numeric = Number.parseFloat(trimmed)
+  if (Number.isNaN(numeric)) {
+    return 1
+  }
+
+  return clamp01(numeric)
+}
+
+const oklabToSrgb = (l: number, a: number, b: number) => {
+  const l_ = l + 0.3963377774 * a + 0.2158037573 * b
+  const m_ = l - 0.1055613458 * a - 0.0638541728 * b
+  const s_ = l - 0.0894841775 * a - 1.291485548 * b
+
+  const l3 = l_ ** 3
+  const m3 = m_ ** 3
+  const s3 = s_ ** 3
+
+  const r = 4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3
+  const g = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3
+  const bChannel = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.707614701 * s3
+
+  return {
+    r: clamp01(r),
+    g: clamp01(g),
+    b: clamp01(bChannel),
+  }
+}
+
+const normalizeOklab = (input: string) => {
+  const inside = input.slice(input.indexOf('(') + 1, input.lastIndexOf(')'))
+  const [labPartRaw, alphaPart] = inside.split('/')
+  const labTokens = (labPartRaw ?? '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0)
+
+  if (labTokens.length < 3) {
+    return input
+  }
+
+  const labValues = labTokens.map((value) => Number.parseFloat(value))
+
+  if (labValues.length < 3 || labValues.some((value) => Number.isNaN(value))) {
+    return input
+  }
+
+  const [l, a, b] = labValues as [number, number, number]
+
+  const { r, g, b: blue } = oklabToSrgb(l, a, b)
+  const alpha = parseAlphaValue(alphaPart)
+
+  return formatRgbString(r, g, blue, alpha)
+}
+
+const normalizeSrgbFunction = (input: string) => {
+  const inside = input.slice(input.indexOf('(') + 1, input.lastIndexOf(')'))
+  const [channelPartRaw, alphaPart] = inside.split('/')
+  const channelPart = channelPartRaw ?? ''
+  const channels = channelPart
+    .replace(/^srgb\s*/i, '')
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0)
+    .map((value) => parseUnitValue(value))
+
+  if (channels.length < 3 || channels.some((channel) => Number.isNaN(channel))) {
+    return input
+  }
+
+  const [r, g, b] = channels as [number, number, number]
+  const alpha = parseAlphaValue(alphaPart)
+
+  return formatRgbString(r, g, b, alpha)
+}
+
+export const normalizeComputedColor = (value: string) => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return ''
+  }
+
+  if (/^rgba?\(/i.test(trimmed)) {
+    return trimmed
+  }
+
+  if (/^oklab\(/i.test(trimmed)) {
+    return normalizeOklab(trimmed)
+  }
+
+  if (/^color\(\s*srgb/i.test(trimmed)) {
+    return normalizeSrgbFunction(trimmed)
+  }
+
+  return trimmed
+}
+
+export type NormalizeComputedColor = typeof normalizeComputedColor

--- a/src/views/ComponentPlayground.vue
+++ b/src/views/ComponentPlayground.vue
@@ -7,6 +7,8 @@ import { ElColorPicker } from 'element-plus'
 import type { LabComponentDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/catalog'
 import { getComponentDefinition } from '@/library/catalog'
 import type { SupportedLocale } from '@/i18n'
+import Spinner from '@/components/library/Spinner.vue'
+import { normalizeComputedColor } from '@/utils/color'
 
 const props = defineProps<{
   componentId: string
@@ -73,15 +75,18 @@ const resolveColorValue = (value: string | undefined) => {
     return ''
   }
 
+  const normalizedInput = normalizeComputedColor(value)
   const resolver = colorResolver.value
+
   if (!resolver) {
-    return value
+    return normalizedInput
   }
 
   resolver.style.color = ''
   resolver.style.color = value
-  console.log(getComputedStyle(resolver).color)
-  return getComputedStyle(resolver).color
+  const computedColor = getComputedStyle(resolver).color
+
+  return normalizeComputedColor(computedColor || normalizedInput)
 }
 
 const updateResolvedColor = (key: string, value: string | undefined) => {
@@ -181,12 +186,12 @@ watch(
           <component :is="previewComponent" v-bind="currentProps" />
           <template #fallback>
             <div class="flex h-full items-center justify-center text-surface-400">
-              <i class="pi pi-spinner animate-spin text-2xl"></i>
+              <Spinner :size="72" :thickness="6" />
             </div>
           </template>
         </Suspense>
         <div v-else class="flex h-full items-center justify-center text-surface-400">
-          <i class="pi pi-spinner animate-spin text-2xl"></i>
+          <Spinner :size="72" :thickness="6" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a color normalization helper that coerces computed CSS colors into rgb/rgba strings
- use the helper when resolving playground color controls to handle oklab and srgb formats
- swap the component preview fallback to the shared Spinner component for a consistent loading state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e22a3b86ec832c9ff6a6c2255191fa