### PR TITLE
Normalize computed style colors for playground previews

### DIFF
--- a/src/library/utils/color.ts
+++ b/src/library/utils/color.ts
@@ -1,0 +1,98 @@
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
+
+const toByte = (value: number) => Math.round(clamp(value, 0, 1) * 255)
+
+const toRgbString = (r: number, g: number, b: number, alpha?: number) => {
+  const rByte = toByte(r)
+  const gByte = toByte(g)
+  const bByte = toByte(b)
+
+  if (alpha === undefined || Number.isNaN(alpha) || alpha >= 1) {
+    return `rgb(${rByte}, ${gByte}, ${bByte})`
+  }
+
+  const normalizedAlpha = clamp(alpha, 0, 1)
+  const alphaRounded = Number.isInteger(normalizedAlpha)
+    ? normalizedAlpha
+    : parseFloat(normalizedAlpha.toFixed(3))
+  const alphaString = `${alphaRounded}`
+  return `rgba(${rByte}, ${gByte}, ${bByte}, ${alphaString})`
+}
+
+const parseNumber = (value: string) => {
+  if (value.endsWith('%')) {
+    return parseFloat(value) / 100
+  }
+
+  return parseFloat(value)
+}
+
+const parseSrgbColor = (value: string) => {
+  const match = value.match(/^color\(srgb\s+([^\s/]+)\s+([^\s/]+)\s+([^\s/]+)(?:\s*\/\s*([^\s)]+))?\)$/i)
+  if (!match) {
+    return null
+  }
+
+  const r = match[1]!
+  const g = match[2]!
+  const b = match[3]!
+  const alpha = match[4]
+  const rValue = parseNumber(r)
+  const gValue = parseNumber(g)
+  const bValue = parseNumber(b)
+  const alphaValue = alpha ? parseNumber(alpha) : undefined
+
+  return toRgbString(rValue, gValue, bValue, alphaValue)
+}
+
+const oklabToSrgb = (l: number, a: number, b: number) => {
+  const l_ = l + 0.3963377774 * a + 0.2158037573 * b
+  const m_ = l - 0.1055613458 * a - 0.0638541728 * b
+  const s_ = l - 0.0894841775 * a - 1.291485548 * b
+
+  const l3 = l_ ** 3
+  const m3 = m_ ** 3
+  const s3 = s_ ** 3
+
+  const rLinear = 4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3
+  const gLinear = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3
+  const bLinear = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.707614701 * s3
+
+  const linearToSrgb = (component: number) =>
+    component <= 0.0031308 ? 12.92 * component : 1.055 * component ** (1 / 2.4) - 0.055
+
+  return {
+    r: linearToSrgb(rLinear),
+    g: linearToSrgb(gLinear),
+    b: linearToSrgb(bLinear),
+  }
+}
+
+const parseOklabColor = (value: string) => {
+  const match = value.match(/^oklab\(\s*([^\s/]+)\s+([^\s/]+)\s+([^\s/]+)(?:\s*\/\s*([^\s)]+))?\s*\)$/i)
+  if (!match) {
+    return null
+  }
+
+  const l = match[1]!
+  const a = match[2]!
+  const b = match[3]!
+  const alpha = match[4]
+  const lValue = parseFloat(l)
+  const aValue = parseFloat(a)
+  const bValue = parseFloat(b)
+  const alphaValue = alpha ? parseNumber(alpha) : undefined
+
+  const { r, g, b: blue } = oklabToSrgb(lValue, aValue, bValue)
+  return toRgbString(r, g, blue, alphaValue)
+}
+
+export const normalizeComputedColor = (value: string) => {
+  const trimmed = value.trim()
+
+  if (/^rgb(a)?\(/i.test(trimmed) || /^#/.test(trimmed)) {
+    return trimmed
+  }
+
+  return parseSrgbColor(trimmed) ?? parseOklabColor(trimmed) ?? trimmed
+}

--- a/src/views/ComponentPlayground.vue
+++ b/src/views/ComponentPlayground.vue
@@ -4,8 +4,10 @@ import type { AsyncComponentLoader, WatchStopHandle } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElColorPicker } from 'element-plus'
+import Spinner from '@/components/library/Spinner.vue'
 import type { LabComponentDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/catalog'
 import { getComponentDefinition } from '@/library/catalog'
+import { normalizeComputedColor } from '@/library/utils/color'
 import type { SupportedLocale } from '@/i18n'
 
 const props = defineProps<{
@@ -80,8 +82,7 @@ const resolveColorValue = (value: string | undefined) => {
 
   resolver.style.color = ''
   resolver.style.color = value
-  console.log(getComputedStyle(resolver).color)
-  return getComputedStyle(resolver).color
+  return normalizeComputedColor(getComputedStyle(resolver).color)
 }
 
 const updateResolvedColor = (key: string, value: string | undefined) => {
@@ -181,12 +182,12 @@ watch(
           <component :is="previewComponent" v-bind="currentProps" />
           <template #fallback>
             <div class="flex h-full items-center justify-center text-surface-400">
-              <i class="pi pi-spinner animate-spin text-2xl"></i>
+              <Spinner :size="72" :thickness="6" indicator-color="var(--p-primary-color)" />
             </div>
           </template>
         </Suspense>
         <div v-else class="flex h-full items-center justify-center text-surface-400">
-          <i class="pi pi-spinner animate-spin text-2xl"></i>
+          <Spinner :size="72" :thickness="6" indicator-color="var(--p-primary-color)" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a utility that normalizes computed color strings (including `color(srgb …)` and `oklab(…)`) to rgb/rgba output
- use the new normalizer when resolving playground color props and replace the preview fallback with the Spinner component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2299c16f0832cb8278d4645041351