### PR TITLE
Simplify ComponentPlayground defaults loading

### DIFF
--- a/src/views/ComponentPlayground.vue
+++ b/src/views/ComponentPlayground.vue
@@ -47,11 +47,7 @@ const loadComponentDefaults = async () => {
     return
   }
 
-  const targetId = definition.value.id
   const module = await definition.value.component()
-  if (definition.value?.id !== targetId) {
-    return
-  }
 
   const defaults = cloneProps((module as { defaultProps?: Record<string, PlaygroundPropValue> }).defaultProps)
   componentDefaults.value = defaults


### PR DESCRIPTION
## Summary
- remove redundant target id safeguard when loading component defaults in ComponentPlayground

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e230ca7f38832c9dab10c0ba8fea7b