### PR TITLE
Refine color utilities and update QR code rendering

### DIFF
--- a/library/components/QrCode.vue
+++ b/library/components/QrCode.vue
@@ -7,8 +7,9 @@ export const defaultProps = {
 </script>
 
 <script setup lang="ts">
-import QrcodeVue from 'qrcode.vue'
-import { resolveColorValue } from '@shared/color'
+import { ref, watch } from 'vue'
+import { toDataURL } from 'qrcode'
+import { colorValueToHex } from '@shared/color'
 
 const props = withDefaults(
   defineProps<{
@@ -20,19 +21,43 @@ const props = withDefaults(
   defaultProps
 )
 
+const qrSource = ref('')
+
+const generateQrCode = async () => {
+  const content = props.content.trim()
+
+  if (!content) {
+    qrSource.value = ''
+    return
+  }
+
+  const darkHex = colorValueToHex(props.darkColor) || '#000000'
+  const lightHex = colorValueToHex(props.lightColor) || '#ffffff'
+
+  qrSource.value = await toDataURL(content, {
+    errorCorrectionLevel: 'H',
+    color: {
+      dark: darkHex,
+      light: lightHex,
+    },
+  })
+}
+
+watch(
+  () => [props.content, props.darkColor, props.lightColor],
+  () => {
+    void generateQrCode()
+  },
+  { immediate: true }
+)
 </script>
 
 <template>
   <section class="flex flex-col items-center text-center">
-    <div class="relative rounded-3xl border border-surface-200 bg-surface-0 p-4 shadow-sm dark:border-surface-700 dark:bg-surface-900">
-      <QrcodeVue
-        :value="props.content"
-        :size="220"
-        :foreground="resolveColorValue(props.darkColor)"
-        :background="resolveColorValue(props.lightColor)"
-        level="H"
-        class="block"
-      />
+    <div
+      class="relative flex aspect-square w-full max-w-[220px] items-center justify-center rounded-3xl border border-surface-200 bg-surface-0 p-4 shadow-sm dark:border-surface-700 dark:bg-surface-900"
+    >
+      <img v-if="qrSource" :src="qrSource" alt="QR code" class="h-full w-full object-contain" />
       <div
         v-if="props.icon?.trim()"
         class="absolute inset-0 flex items-center justify-center"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,14 @@
         "element-plus": "^2.11.4",
         "primeicons": "^7.0.0",
         "primevue": "^4.4.0",
-        "qrcode.vue": "^3.6.0",
+        "qrcode": "^1.5.4",
         "vue": "^3.5.22",
         "vue-i18n": "^9.14.5",
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@types/node": "^24.6.0",
+        "@types/qrcode": "^1.5.5",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vue/tsconfig": "^0.8.1",
         "autoprefixer": "^10.4.21",
@@ -1163,6 +1164,16 @@
         "undici-types": "~7.13.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.5.tgz",
+      "integrity": "sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.16",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.16.tgz",
@@ -1657,6 +1668,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1726,11 +1746,91 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1743,7 +1843,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -1796,12 +1895,27 @@
       "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
       "license": "MIT"
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -2004,6 +2118,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2058,6 +2185,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob": {
@@ -2150,7 +2286,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2228,6 +2363,18 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -2427,6 +2574,42 @@
         "node": ">= 6"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -2440,6 +2623,15 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -2512,6 +2704,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -2704,13 +2905,21 @@
         "node": ">=12.11.0"
       }
     },
-    "node_modules/qrcode.vue": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/qrcode.vue/-/qrcode.vue-3.6.0.tgz",
-      "integrity": "sha512-vQcl2fyHYHMjDO1GguCldJxepq2izQjBkDEEu9NENgfVKP6mv/e2SU62WbqYHGwTgWXLhxZ1NCD1dAZKHQq1fg==",
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
       "license": "MIT",
-      "peerDependencies": {
-        "vue": "^3.0.0"
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/queue-microtask": {
@@ -2769,6 +2978,21 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -2867,6 +3091,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3391,6 +3621,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -3489,6 +3725,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
@@ -3500,6 +3742,82 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
     "element-plus": "^2.11.4",
     "primeicons": "^7.0.0",
     "primevue": "^4.4.0",
-    "qrcode.vue": "^3.6.0",
+    "qrcode": "^1.5.4",
     "vue": "^3.5.22",
     "vue-i18n": "^9.14.5",
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
+    "@types/qrcode": "^1.5.5",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/tsconfig": "^0.8.1",
     "autoprefixer": "^10.4.21",

--- a/playground/src/views/ComponentPlayground.vue
+++ b/playground/src/views/ComponentPlayground.vue
@@ -7,7 +7,7 @@ import { ElColorPicker } from 'element-plus'
 import Spinner from '@library/components/Spinner.vue'
 import type { LabComponentDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/catalog'
 import { getComponentDefinition } from '@/library/catalog'
-import { resolveColorValue } from '@shared/color'
+import { colorValueToRgba } from '@shared/color'
 import type { SupportedLocale } from '@/i18n'
 
 const props = defineProps<{
@@ -71,7 +71,7 @@ watchEffect(() => {
   const activeKeys = new Set(keys)
   keys.forEach((key) => {
     const value = currentProps[key]
-    resolvedColors[key] = resolveColorValue(typeof value === 'string' ? value : undefined)
+    resolvedColors[key] = colorValueToRgba(typeof value === 'string' ? value : undefined)
   })
 
   Object.keys(resolvedColors).forEach((key) => {

--- a/shared/color.ts
+++ b/shared/color.ts
@@ -1,7 +1,7 @@
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
 const toByte = (value: number) => Math.round(clamp(value, 0, 1) * 255)
 
-const toRgbString = (r: number, g: number, b: number, alpha?: number) => {
+const srgbComponentsToCssColor = (r: number, g: number, b: number, alpha?: number) => {
   const rByte = toByte(r)
   const gByte = toByte(g)
   const bByte = toByte(b)
@@ -18,7 +18,7 @@ const toRgbString = (r: number, g: number, b: number, alpha?: number) => {
   return `rgba(${rByte}, ${gByte}, ${bByte}, ${alphaString})`
 }
 
-const parseNumber = (value: string) => {
+const colorComponentStringToNumber = (value: string) => {
   if (value.endsWith('%')) {
     return parseFloat(value) / 100
   }
@@ -26,7 +26,7 @@ const parseNumber = (value: string) => {
   return parseFloat(value)
 }
 
-const parseSrgbColor = (value: string) => {
+const srgbFunctionStringToCssColor = (value: string) => {
   const match = value.match(/^color\(srgb\s+([^\s/]+)\s+([^\s/]+)\s+([^\s/]+)(?:\s*\/\s*([^\s)]+))?\)$/i)
   if (!match) {
     return null
@@ -36,12 +36,12 @@ const parseSrgbColor = (value: string) => {
   const g = match[2]!
   const b = match[3]!
   const alpha = match[4]
-  const rValue = parseNumber(r)
-  const gValue = parseNumber(g)
-  const bValue = parseNumber(b)
-  const alphaValue = alpha ? parseNumber(alpha) : undefined
+  const rValue = colorComponentStringToNumber(r)
+  const gValue = colorComponentStringToNumber(g)
+  const bValue = colorComponentStringToNumber(b)
+  const alphaValue = alpha ? colorComponentStringToNumber(alpha) : undefined
 
-  return toRgbString(rValue, gValue, bValue, alphaValue)
+  return srgbComponentsToCssColor(rValue, gValue, bValue, alphaValue)
 }
 
 const oklabToSrgb = (l: number, a: number, b: number) => {
@@ -67,7 +67,7 @@ const oklabToSrgb = (l: number, a: number, b: number) => {
   }
 }
 
-const parseOklabColor = (value: string) => {
+const oklabFunctionStringToCssColor = (value: string) => {
   const match = value.match(/^oklab\(\s*([^\s/]+)\s+([^\s/]+)\s+([^\s/]+)(?:\s*\/\s*([^\s)]+))?\s*\)$/i)
   if (!match) {
     return null
@@ -80,20 +80,20 @@ const parseOklabColor = (value: string) => {
   const lValue = parseFloat(l)
   const aValue = parseFloat(a)
   const bValue = parseFloat(b)
-  const alphaValue = alpha ? parseNumber(alpha) : undefined
+  const alphaValue = alpha ? colorComponentStringToNumber(alpha) : undefined
 
   const { r, g, b: blue } = oklabToSrgb(lValue, aValue, bValue)
-  return toRgbString(r, g, blue, alphaValue)
+  return srgbComponentsToCssColor(r, g, blue, alphaValue)
 }
 
-const normalizeComputedColor = (value: string) => {
+const cssColorStringToCssRgba = (value: string) => {
   const trimmed = value.trim()
 
   if (/^rgb(a)?\(/i.test(trimmed) || /^#/.test(trimmed)) {
     return trimmed
   }
 
-  return parseSrgbColor(trimmed) ?? parseOklabColor(trimmed) ?? trimmed
+  return srgbFunctionStringToCssColor(trimmed) ?? oklabFunctionStringToCssColor(trimmed) ?? trimmed
 }
 
 let colorResolver: HTMLDivElement | null = null
@@ -112,22 +112,78 @@ const ensureColorResolver = () => {
   return colorResolver
 }
 
-export const resolveColorValue = (value: string | undefined) => {
+const rgbaStringToComponents = (value: string) => {
+  const match = value.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i)
+  if (!match) {
+    return null
+  }
+
+  const r = parseFloat(match[1]!)
+  const g = parseFloat(match[2]!)
+  const b = parseFloat(match[3]!)
+  const alpha = match[4] !== undefined ? parseFloat(match[4]) : undefined
+
+  return { r, g, b, alpha }
+}
+
+const toHexComponent = (value: number) => Math.round(clamp(value, 0, 255)).toString(16).padStart(2, '0')
+
+export const rgbaToHex = (value: string) => {
+  const components = rgbaStringToComponents(value)
+
+  if (!components) {
+    return ''
+  }
+
+  const { r, g, b, alpha } = components
+  const rHex = toHexComponent(r)
+  const gHex = toHexComponent(g)
+  const bHex = toHexComponent(b)
+
+  if (alpha === undefined || Number.isNaN(alpha) || alpha >= 1) {
+    return `#${rHex}${gHex}${bHex}`
+  }
+
+  const alphaHex = toHexComponent(alpha * 255)
+  return `#${rHex}${gHex}${bHex}${alphaHex}`
+}
+
+const resolveColor = (value: string | undefined) => {
   if (!value) {
     return ''
   }
 
   const trimmed = value.trim()
-  const fallback = normalizeComputedColor(trimmed)
+  const fallback = cssColorStringToCssRgba(trimmed)
   const resolver = ensureColorResolver()
 
-  if (!resolver || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+  if (!resolver) {
     return fallback
   }
 
   resolver.style.color = ''
   resolver.style.color = trimmed
-  const resolved = window.getComputedStyle(resolver).color
+  const resolved = globalThis.getComputedStyle?.(resolver)?.color
 
-  return normalizeComputedColor(resolved || fallback)
+  if (!resolved) {
+    return fallback
+  }
+
+  return cssColorStringToCssRgba(resolved)
+}
+
+export const colorValueToRgba = (value: string | undefined) => resolveColor(value)
+
+export const colorValueToHex = (value: string | undefined) => {
+  const rgba = resolveColor(value)
+
+  if (!rgba) {
+    return ''
+  }
+
+  if (rgba.startsWith('#')) {
+    return rgba
+  }
+
+  return rgbaToHex(rgba)
 }


### PR DESCRIPTION
## Summary
- rename the shared color helpers with explicit `_to_` conversions and add an `rgbaToHex` utility
- expose dedicated `colorValueToHex` and `colorValueToRgba` resolvers for callers that need CSS strings
- replace the `qrcode.vue` dependency with data URL generation so the preview image can resize responsively

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2653050d4832ca2a8358b6b9d1f6e