### PR TITLE
Add spinner text styling props to LoadingOverlay

### DIFF
--- a/library/components/LoadingOverlay.vue
+++ b/library/components/LoadingOverlay.vue
@@ -9,6 +9,8 @@ export const defaultProps = {
   spinnerTrackColor: 'color-mix(in srgb, var(--p-surface-0) 25%, transparent)',
   spinnerIndicatorColor: 'var(--p-primary-contrast-color)',
   spinnerText: '',
+  spinnerTextSize: 18,
+  spinnerTextColor: undefined as string | undefined,
 } as const
 
 export type props = {
@@ -21,6 +23,8 @@ export type props = {
   spinnerTrackColor?: string
   spinnerIndicatorColor?: string
   spinnerText?: string | number
+  spinnerTextSize?: number
+  spinnerTextColor?: string
 }
 </script>
 
@@ -50,7 +54,8 @@ const hasDescription = computed(() => Boolean(props.description?.trim()))
           :track-color="props.spinnerTrackColor"
           :indicator-color="props.spinnerIndicatorColor"
           :text="props.spinnerText"
-          :text-size="18"
+          :text-size="props.spinnerTextSize"
+          :text-color="props.spinnerTextColor"
         />
         <p v-if="hasDescription" class="max-w-xs text-sm text-surface-0/80">{{ props.description }}</p>
       </div>

--- a/library/components/Spinner.vue
+++ b/library/components/Spinner.vue
@@ -4,6 +4,7 @@ export const defaultProps = {
   size: 96,
   thickness: 8,
   textSize: 22,
+  textColor: undefined as string | undefined,
   trackColor: 'color-mix(in srgb, var(--p-surface-400) 35%, transparent)',
   indicatorColor: 'var(--p-primary-color)',
 } as const
@@ -13,6 +14,7 @@ export type props = {
   size?: number
   thickness?: number
   textSize?: number
+  textColor?: string
   trackColor?: string
   indicatorColor?: string
 }
@@ -30,10 +32,18 @@ const displayText = computed(() => `${props.text ?? ''}`)
 const trimmedText = computed(() => displayText.value.trim())
 const hasText = computed(() => trimmedText.value.length > 0)
 
-const textStyle = computed(() => ({
-  fontSize: `${props.textSize}px`,
-  lineHeight: '1',
-}))
+const textStyle = computed(() => {
+  const style: Record<string, string> = {
+    fontSize: `${props.textSize}px`,
+    lineHeight: '1',
+  }
+
+  if (props.textColor) {
+    style.color = props.textColor
+  }
+
+  return style
+})
 
 const dimensions = computed(() => ({
   width: `${props.size}px`,

--- a/playground/src/demos/LoadingOverlayDemo.vue
+++ b/playground/src/demos/LoadingOverlayDemo.vue
@@ -11,6 +11,8 @@ defineProps<{
   spinnerTrackColor?: string
   spinnerIndicatorColor?: string
   spinnerText?: string | number
+  spinnerTextSize?: number
+  spinnerTextColor?: string
 }>()
 </script>
 

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -218,6 +218,14 @@ export const componentCatalog: LabComponentDefinition[] = [
         step: 4,
       },
       {
+        key: 'spinnerTextSize',
+        type: 'slider',
+        label: { en: 'Text Size', ko: '텍스트 크기' },
+        min: 12,
+        max: 64,
+        step: 1,
+      },
+      {
         key: 'spinnerThickness',
         type: 'slider',
         label: { en: 'Spinner Thickness', ko: '스피너 두께' },
@@ -234,6 +242,11 @@ export const componentCatalog: LabComponentDefinition[] = [
         key: 'spinnerTrackColor',
         type: 'color',
         label: { en: 'Track Color', ko: '트랙 색상' },
+      },
+      {
+        key: 'spinnerTextColor',
+        type: 'color',
+        label: { en: 'Text Color', ko: '텍스트 색상' },
       },
       {
         key: 'overlayColor',


### PR DESCRIPTION
## Summary
- allow LoadingOverlay consumers to configure spinner text size and color
- extend the shared Spinner component and playground demo to surface the new props

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e298b68b38832ca078f85c14c41f8e