### PR TITLE
refactor: move library exports under components index

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ playground/
 ```
 
 To register a new component:
-1. Create the component under `library/components/` (and export it from `library/index.ts`).
+1. Create the component under `library/components/` (and export it from `library/components/index.ts`).
 2. (Optional) Create a demo wrapper under `playground/src/demos/` if the component needs slot scaffolding.
 3. Add an entry to `playground/src/library/catalog.ts` with localized metadata, default props, and control definitions.
 

--- a/library/components/index.ts
+++ b/library/components/index.ts
@@ -1,0 +1,9 @@
+export { default as BlurOverlay } from './BlurOverlay.vue'
+export { default as LoadingOverlay } from './LoadingOverlay.vue'
+export { default as QrCode } from './QrCode.vue'
+export { default as Spinner } from './Spinner.vue'
+
+export type { props as BlurOverlayProps } from './BlurOverlay.vue'
+export type { props as LoadingOverlayProps } from './LoadingOverlay.vue'
+export type { props as QrCodeProps } from './QrCode.vue'
+export type { props as SpinnerProps } from './Spinner.vue'

--- a/library/index.ts
+++ b/library/index.ts
@@ -1,8 +1,0 @@
-export { default as BlurOverlay } from './components/BlurOverlay.vue'
-export { default as LoadingOverlay } from './components/LoadingOverlay.vue'
-export { default as QrCode } from './components/QrCode.vue'
-export { default as Spinner } from './components/Spinner.vue'
-export type { props as BlurOverlayProps } from './components/BlurOverlay.vue'
-export type { props as LoadingOverlayProps } from './components/LoadingOverlay.vue'
-export type { props as QrCodeProps } from './components/QrCode.vue'
-export type { props as SpinnerProps } from './components/Spinner.vue'

--- a/playground/src/demos/BlurOverlayDemo.vue
+++ b/playground/src/demos/BlurOverlayDemo.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
-import BlurOverlay from '@library/components/BlurOverlay.vue'
+import { BlurOverlay, type BlurOverlayProps } from '@library/components'
 
-defineProps<{
-  visible: boolean
-  blur: number
-  overlayColor: string
-}>()
+defineProps<BlurOverlayProps>()
 </script>
 
 <template>

--- a/playground/src/demos/LoadingOverlayDemo.vue
+++ b/playground/src/demos/LoadingOverlayDemo.vue
@@ -1,19 +1,7 @@
 <script setup lang="ts">
-import LoadingOverlay from '@library/components/LoadingOverlay.vue'
+import { LoadingOverlay, type LoadingOverlayProps } from '@library/components'
 
-defineProps<{
-  visible: boolean
-  blur: number
-  description: string
-  overlayColor?: string
-  spinnerSize?: number
-  spinnerThickness?: number
-  spinnerTrackColor?: string
-  spinnerIndicatorColor?: string
-  spinnerText?: string | number
-  spinnerTextSize?: number
-  spinnerTextColor?: string
-}>()
+defineProps<LoadingOverlayProps>()
 </script>
 
 <template>

--- a/playground/src/demos/QrCodeDemo.vue
+++ b/playground/src/demos/QrCodeDemo.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
-import QrCode from '@library/components/QrCode.vue'
+import { QrCode, type QrCodeProps } from '@library/components'
 
-defineProps<{
-  content: string
-  lightColor: string
-  darkColor: string
-  icon?: string
-}>()
+defineProps<QrCodeProps>()
 </script>
 
 <template>

--- a/playground/src/demos/SpinnerDemo.vue
+++ b/playground/src/demos/SpinnerDemo.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
-import Spinner from '@library/components/Spinner.vue'
+import { Spinner, type SpinnerProps } from '@library/components'
 
-defineProps<{
-  text?: string | number
-  size: number
-  thickness: number
-  textSize: number
-  trackColor: string
-  indicatorColor: string
-}>()
+defineProps<SpinnerProps>()
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- move the library export barrel into `library/components/index.ts`
- update component demos to import components and prop types from the new barrel
- refresh documentation to point to the relocated export file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2ad233bc4832cbd96af7a479a067d