### PR TITLE
Rename blur prop to blurStrength

### DIFF
--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -1,13 +1,13 @@
 <script lang="ts">
 export const defaultProps = {
   visible: true,
-  blur: 7,
+  blurStrength: 7,
   overlayColor: 'rgba(0, 0, 0, 0.25)',
 } as const
 
 export type props = {
   visible?: boolean
-  blur?: number
+  blurStrength?: number
   overlayColor?: string
 }
 </script>
@@ -21,8 +21,8 @@ const props = withDefaults(
 )
 
 const overlayStyle = computed(() => ({
-  backdropFilter: `blur(${props.blur}px)`,
-  WebkitBackdropFilter: `blur(${props.blur}px)`,
+  backdropFilter: `blur(${props.blurStrength}px)`,
+  WebkitBackdropFilter: `blur(${props.blurStrength}px)`,
   background: props.overlayColor,
 }))
 </script>

--- a/library/components/LoadingOverlay.vue
+++ b/library/components/LoadingOverlay.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 export const defaultProps = {
   visible: true,
-  blur: 7,
+  blurStrength: 7,
   overlayColor: 'rgba(0, 0, 0, 0.25)',
   spinnerDiameter: 48,
   spinnerThickness: 4,
@@ -11,7 +11,7 @@ export const defaultProps = {
 
 export type props = {
   visible?: boolean
-  blur?: number
+  blurStrength?: number
   overlayColor?: string
   spinnerDiameter?: number
   spinnerThickness?: number
@@ -38,7 +38,7 @@ const hasDescription = computed(() => Boolean(props.description?.trim()))
 </script>
 
 <template>
-  <BlurOverlay :visible="props.visible" :blur="props.blur" :overlay-color="props.overlayColor">
+  <BlurOverlay :visible="props.visible" :blur-strength="props.blurStrength" :overlay-color="props.overlayColor">
     <template #default>
       <slot />
     </template>


### PR DESCRIPTION
## Summary
- rename the BlurOverlay component prop from `blur` to `blurStrength`
- propagate the new prop to LoadingOverlay so it forwards the value correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2b9e00c78832c99f5c787b2dcd9b3