### PR TITLE
Remove visible prop from overlay components

### DIFF
--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -1,12 +1,10 @@
 <script lang="ts">
 export const defaultProps = {
-  visible: true,
   blurStrength: 7,
   overlayColor: 'rgba(0, 0, 0, 0.25)',
 } as const
 
 export type props = {
-  visible?: boolean
   blurStrength?: number
   overlayColor?: string
 }
@@ -30,7 +28,6 @@ const overlayStyle = computed(() => ({
 <template>
   <transition name="fade-blur">
     <div
-      v-if="props.visible"
       class="pointer-events-none absolute inset-0 flex items-center justify-center rounded-inherit border border-surface-0/10 text-surface-0 backdrop-blur"
       :style="overlayStyle"
     >

--- a/library/components/LoadingOverlay.vue
+++ b/library/components/LoadingOverlay.vue
@@ -5,7 +5,6 @@ export const defaultProps = {
 } as const
 
 export type props = {
-  visible?: boolean
   blurStrength?: number
   overlayColor?: string
   spinnerDiameter?: number
@@ -35,7 +34,7 @@ const hasDescription = computed(() => Boolean(props.description?.trim()))
 <template>
   <div class="relative isolate">
     <slot />
-    <BlurOverlay :visible="props.visible" :blur-strength="props.blurStrength" :overlay-color="props.overlayColor">
+    <BlurOverlay :blur-strength="props.blurStrength" :overlay-color="props.overlayColor">
       <template #overlay>
         <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
           <Spinner

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -146,11 +146,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     preview: () => import('@/demos/BlurOverlayDemo.vue'),
     controls: [
       {
-        key: 'visible',
-        type: 'boolean',
-        label: { en: 'Visible', ko: '표시' },
-      },
-      {
         key: 'blurStrength',
         type: 'slider',
         label: { en: 'Blur Strength', ko: '블러 강도' },
@@ -178,11 +173,6 @@ export const componentCatalog: LabComponentDefinition[] = [
     component: () => import('@library/components/LoadingOverlay.vue'),
     preview: () => import('@/demos/LoadingOverlayDemo.vue'),
     controls: [
-      {
-        key: 'visible',
-        type: 'boolean',
-        label: { en: 'Visible', ko: '표시' },
-      },
       {
         key: 'spinnerDiameter',
         type: 'slider',


### PR DESCRIPTION
## Summary
- remove the `visible` prop from BlurOverlay and LoadingOverlay components
- update the component catalog controls to match the new overlay APIs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2cad04a9c832ca2583b5489fa98fe