### PR TITLE
Rename blur overlay color prop to background color

### DIFF
--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
 export const defaultProps = {
   blurStrength: 7,
-  overlayColor: 'rgba(0, 0, 0, 0.25)',
+  backgroundColor: 'rgba(0, 0, 0, 0.25)',
 } as const
 
 export type props = {
   blurStrength?: number
-  overlayColor?: string
+  backgroundColor?: string
 }
 </script>
 
@@ -21,7 +21,7 @@ const props = withDefaults(
 const overlayStyle = computed(() => ({
   backdropFilter: `blur(${props.blurStrength}px)`,
   WebkitBackdropFilter: `blur(${props.blurStrength}px)`,
-  background: props.overlayColor,
+  background: props.backgroundColor,
 }))
 </script>
 

--- a/library/components/LoadingOverlay.vue
+++ b/library/components/LoadingOverlay.vue
@@ -10,7 +10,7 @@ export const defaultProps = {
 export type props = {
   overlay?: {
     blurStrength?: number
-    overlayColor?: string
+    backgroundColor?: string
   }
   spinner?: {
     text?: string | number
@@ -41,7 +41,7 @@ const hasDescription = computed(() => Boolean(props.description?.trim()))
 <template>
   <div class="relative isolate">
     <slot />
-    <BlurOverlay :blur-strength="props.overlay.blurStrength" :overlay-color="props.overlay.overlayColor">
+    <BlurOverlay :blur-strength="props.overlay.blurStrength" :background-color="props.overlay.backgroundColor">
       <template #overlay>
         <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
           <Spinner

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -170,9 +170,9 @@ export const componentCatalog: LabComponentDefinition[] = [
         step: 1,
       },
       {
-        key: 'overlayColor',
+        key: 'backgroundColor',
         type: 'color',
-        label: { en: 'Overlay Color', ko: '오버레이 색상' },
+        label: { en: 'Background Color', ko: '배경 색상' },
       },
     ],
   },
@@ -244,9 +244,9 @@ export const componentCatalog: LabComponentDefinition[] = [
         group: spinnerControlGroup,
       },
       {
-        key: 'overlay.overlayColor',
+        key: 'overlay.backgroundColor',
         type: 'color',
-        label: { en: 'Overlay Color', ko: '오버레이 색상' },
+        label: { en: 'Overlay Background', ko: '오버레이 배경' },
         group: overlayControlGroup,
       },
       {

--- a/playground/src/views/ComponentPlayground.vue
+++ b/playground/src/views/ComponentPlayground.vue
@@ -277,7 +277,7 @@ watchEffect(() => {
 
 const resetProps = () => {
   resetActiveControls()
-  applyDefaults(componentDefaults as Record<string, PlaygroundPropValue>)
+  applyDefaults(componentDefaults.value)
 }
   
 const setColorPropValue = (key: string, value: string | null) => {


### PR DESCRIPTION
## Summary
- rename the blur overlay color prop to `backgroundColor` and adjust loading overlay usage
- update catalog control keys and labels to reflect the new background color prop naming
- fix the playground reset helper to read defaults from the ref value so type checking passes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3269dcc9c832ca1d80ab79cc16d1a