### PR TITLE
Refactor control field color handling

### DIFF
--- a/playground/src/views/core/controls/components/ControlField.vue
+++ b/playground/src/views/core/controls/components/ControlField.vue
@@ -8,19 +8,18 @@ import Textarea from 'primevue/textarea'
 import { ElColorPicker } from 'element-plus'
 import type { ControlDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/catalog'
 import type { SupportedLocale } from '@/i18n'
+import { toRgba } from '@shared/color'
 
 const props = defineProps<{
   control: ControlDefinition
   value: PlaygroundPropValue | undefined
   isOptional: boolean
   isActive: boolean
-  resolvedColor?: string
 }>()
 
 const emit = defineEmits<{
   (event: 'update:value', value: PlaygroundPropValue | undefined): void
   (event: 'toggle-optional', value: boolean | undefined): void
-  (event: 'update-color', value: string | null): void
 }>()
 
 const { t, locale } = useI18n()
@@ -41,6 +40,11 @@ const toggleLabel = computed(() =>
 const stringModel = computed<string | undefined>({
   get: () => (typeof props.value === 'string' ? props.value : undefined),
   set: (value) => emit('update:value', value),
+})
+
+const colorModel = computed<string | null>({
+  get: () => toRgba(stringModel.value),
+  set: (value) => emit('update:value', value ?? ''),
 })
 
 const numberModel = computed<number | undefined>({
@@ -98,13 +102,11 @@ const booleanModel = computed<boolean | undefined>({
     <template v-else-if="control.type === 'color'">
       <div v-if="isActive" class="flex items-center gap-3">
         <ElColorPicker
-          :model-value="resolvedColor ?? ''"
+          v-model="colorModel"
           show-alpha
           color-format="rgb"
           class="shrink-0"
           :aria-labelledby="isOptional ? labelId : undefined"
-          @active-change="emit('update-color', $event)"
-          @update:model-value="emit('update-color', $event)"
         />
         <InputText
           :id="inputId"

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -2,7 +2,6 @@
 import { computed, reactive, ref, watch, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ControlDefinition, LabComponentDefinition, PlaygroundPropValue } from '@/library/catalog'
-import { toRgba } from '@shared/color'
 import ControlField from './components/ControlField.vue'
 import ControlSection from './components/ControlSection.vue'
 
@@ -30,7 +29,6 @@ const cloneProps = (value?: Record<string, PlaygroundPropValue>) => {
 
 const componentDefaults = ref<Record<string, PlaygroundPropValue>>({})
 const currentProps = reactive<Record<string, PlaygroundPropValue>>({})
-const resolvedColors = reactive<Record<string, string>>({})
 const activeControls = reactive<Record<string, boolean>>({})
 const storedOptionalValues = reactive<Record<string, PlaygroundPropValue>>({})
 const collapsedSections = reactive<Record<string, boolean>>({})
@@ -89,7 +87,6 @@ const isControlActive = (control: ControlDefinition) => !isControlOptional(contr
 const applyDefaults = (defaults: Record<string, PlaygroundPropValue>) => {
   const clonedDefaults = cloneProps(defaults)
   Object.keys(currentProps).forEach((key) => delete currentProps[key])
-  Object.keys(resolvedColors).forEach((key) => delete resolvedColors[key])
   Object.entries(clonedDefaults).forEach(([key, value]) => {
     const control = props.definition.controls.find((item) => item.key === key)
     if (!control || isControlActive(control)) {
@@ -145,9 +142,6 @@ const handleOptionalToggle = (control: ControlDefinition, isActive: boolean | un
       storedOptionalValues[control.key] = currentProps[control.key]
       delete currentProps[control.key]
     }
-    if (control.type === 'color') {
-      delete resolvedColors[control.key]
-    }
   }
 
   activeControls[control.key] = checked
@@ -170,7 +164,6 @@ watch(
     const token = ++definitionLoadToken
     componentDefaults.value = {}
     Object.keys(currentProps).forEach((key) => delete currentProps[key])
-    Object.keys(resolvedColors).forEach((key) => delete resolvedColors[key])
     Object.keys(activeControls).forEach((key) => delete activeControls[key])
     Object.keys(storedOptionalValues).forEach((key) => delete storedOptionalValues[key])
     Object.keys(collapsedSections).forEach((key) => delete collapsedSections[key])
@@ -217,31 +210,9 @@ watch(
   { immediate: true }
 )
 
-watchEffect(() => {
-  const keys = props.definition.controls
-    .filter((control) => control.type === 'color')
-    .map((control) => control.key)
-
-  const activeKeys = new Set(keys)
-  keys.forEach((key) => {
-    const value = currentProps[key]
-    resolvedColors[key] = toRgba(typeof value === 'string' ? value : undefined)
-  })
-
-  Object.keys(resolvedColors).forEach((key) => {
-    if (!activeKeys.has(key)) {
-      delete resolvedColors[key]
-    }
-  })
-})
-
 const resetProps = () => {
   resetActiveControls()
   applyDefaults(componentDefaults.value)
-}
-
-const setColorPropValue = (key: string, value: string | null) => {
-  currentProps[key] = (value ?? '') as PlaygroundPropValue
 }
 
 const toggleSection = (sectionId: string) => {
@@ -330,10 +301,8 @@ const isSectionCollapsed = (sectionId: string, hasGroup: boolean) => {
             :value="currentProps[control.key] as PlaygroundPropValue | undefined"
             :is-optional="isControlOptional(control)"
             :is-active="isControlActive(control)"
-            :resolved-color="resolvedColors[control.key]"
             @toggle-optional="handleOptionalToggle(control, $event)"
             @update:value="updateControlValue(control.key, $event)"
-            @update-color="setColorPropValue(control.key, $event)"
           />
         </ControlSection>
         <hr


### PR DESCRIPTION
## Summary
- remove the shared resolved color bookkeeping from the controls index view
- compute and bind normalized color values directly inside `ControlField`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e33e5bdd74832c9de30c063032b42c