### PR TITLE
Refactor controls section to manage its own collapse state

### DIFF
--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref, watch, watchEffect } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ControlDefinition, LabComponentDefinition, PlaygroundPropValue } from '@/library/catalog'
 import Field from './field.vue'
@@ -31,7 +31,6 @@ const componentDefaults = ref<Record<string, PlaygroundPropValue>>({})
 const currentProps = reactive<Record<string, PlaygroundPropValue>>({})
 const activeControls = reactive<Record<string, boolean>>({})
 const storedOptionalValues = reactive<Record<string, PlaygroundPropValue>>({})
-const collapsedSections = reactive<Record<string, boolean>>({})
 
 const controlSections = computed(() => {
   const UNGROUPED_ID = '__ungrouped__'
@@ -55,28 +54,6 @@ const controlSections = computed(() => {
   })
 
   return sections
-})
-
-watchEffect(() => {
-  const sections = controlSections.value
-  const validSectionIds = new Set(sections.map((section) => section.id))
-
-  sections.forEach((section) => {
-    if (!Object.prototype.hasOwnProperty.call(collapsedSections, section.id)) {
-      collapsedSections[section.id] = section.group ? true : false
-      return
-    }
-
-    if (!section.group) {
-      collapsedSections[section.id] = false
-    }
-  })
-
-  Object.keys(collapsedSections).forEach((id) => {
-    if (!validSectionIds.has(id)) {
-      delete collapsedSections[id]
-    }
-  })
 })
 
 const hasOwn = (object: Record<string, unknown>, key: string) => Object.prototype.hasOwnProperty.call(object, key)
@@ -166,7 +143,6 @@ watch(
     Object.keys(currentProps).forEach((key) => delete currentProps[key])
     Object.keys(activeControls).forEach((key) => delete activeControls[key])
     Object.keys(storedOptionalValues).forEach((key) => delete storedOptionalValues[key])
-    Object.keys(collapsedSections).forEach((key) => delete collapsedSections[key])
     const module = await nextDefinition.component()
     if (token !== definitionLoadToken) {
       return
@@ -213,10 +189,6 @@ watch(
 const resetProps = () => {
   resetActiveControls()
   applyDefaults(componentDefaults.value)
-}
-
-const toggleSection = (sectionId: string) => {
-  collapsedSections[sectionId] = !(collapsedSections[sectionId] ?? true)
 }
 
 const resolvedComponentProps = computed(() => {
@@ -267,14 +239,6 @@ watch(
   { immediate: true, deep: true }
 )
 
-const isSectionCollapsed = (sectionId: string, hasGroup: boolean) => {
-  if (!hasGroup) {
-    return false
-  }
-
-  return collapsedSections[sectionId] ?? true
-}
-
 </script>
 
 <template>
@@ -290,9 +254,6 @@ const isSectionCollapsed = (sectionId: string, hasGroup: boolean) => {
       <div v-for="(section, sectionIndex) in controlSections" :key="section.id" class="flex flex-col gap-4">
         <Section
           :section="section"
-          :is-collapsed="isSectionCollapsed(section.id, Boolean(section.group))"
-          :has-group="Boolean(section.group)"
-          @toggle="toggleSection(section.id)"
         >
           <Field
             v-for="control in section.controls"

--- a/playground/src/views/core/controls/section.vue
+++ b/playground/src/views/core/controls/section.vue
@@ -1,24 +1,35 @@
 <script setup lang="ts">
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ControlDefinition, LocaleCopy } from '@/library/catalog'
 import type { SupportedLocale } from '@/i18n'
 
-defineProps<{
+const props = defineProps<{
   section: { id: string; group?: ControlDefinition['group']; controls: ControlDefinition[] }
-  isCollapsed: boolean
-  hasGroup: boolean
-}>()
-
-const emit = defineEmits<{
-  (event: 'toggle'): void
 }>()
 
 const { locale } = useI18n()
 
+const hasGroup = computed(() => Boolean(props.section.group))
+const isCollapsed = ref(hasGroup.value)
+
+watch(
+  hasGroup,
+  (value) => {
+    if (!value) {
+      isCollapsed.value = false
+    }
+  }
+)
+
 const localize = (copy: LocaleCopy) => copy[locale.value as SupportedLocale] ?? copy.en
 
 const handleToggle = () => {
-  emit('toggle')
+  if (!hasGroup.value) {
+    return
+  }
+
+  isCollapsed.value = !isCollapsed.value
 }
 </script>
 


### PR DESCRIPTION
## Summary
- move the controls section collapse state into the Section component so each section manages its own visibility
- simplify the controls view by removing the shared collapsed sections registry and relying on the Section component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e345e3810c832c9da7b4e6d51443f3