### PR TITLE
Refactor preview prop resolution and sync controls

### DIFF
--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -7,11 +7,11 @@ import Section from './section.vue'
 
 const props = defineProps<{
   definition: LabComponentDefinition
+  props?: Record<string, PlaygroundPropValue>
 }>()
 
 const emit = defineEmits<{
   (event: 'update:props', value: Record<string, PlaygroundPropValue>): void
-  (event: 'update:resolved-props', value: Record<string, unknown>): void
 }>()
 
 const { t } = useI18n()
@@ -191,50 +191,10 @@ const resetProps = () => {
   applyDefaults(componentDefaults.value)
 }
 
-const resolvedComponentProps = computed(() => {
-  const expanded: Record<string, unknown> = {}
-
-  Object.entries(currentProps).forEach(([path, value]) => {
-    const segments = path.split('.')
-    if (segments.length === 0) {
-      return
-    }
-
-    let target: Record<string, unknown> = expanded
-    for (let index = 0; index < segments.length - 1; index += 1) {
-      const segment = segments[index]
-      if (!segment) {
-        return
-      }
-      const existing = target[segment]
-      if (!existing || typeof existing !== 'object' || Array.isArray(existing)) {
-        target[segment] = {}
-      }
-      target = target[segment] as Record<string, unknown>
-    }
-
-    const lastSegment = segments[segments.length - 1]
-    if (!lastSegment) {
-      return
-    }
-    target[lastSegment] = value as unknown
-  })
-
-  return expanded
-})
-
 watch(
   currentProps,
   (value) => {
     emit('update:props', cloneProps(value))
-  },
-  { immediate: true, deep: true }
-)
-
-watch(
-  resolvedComponentProps,
-  (value) => {
-    emit('update:resolved-props', value)
   },
   { immediate: true, deep: true }
 )

--- a/playground/src/views/core/index.vue
+++ b/playground/src/views/core/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import type { LabComponentDefinition } from '@/library/catalog'
+import type { LabComponentDefinition, PlaygroundPropValue } from '@/library/catalog'
 import { getComponentDefinition } from '@/library/catalog'
 import Controls from './controls/index.vue'
 import NotFound from './notFound.vue'
@@ -12,22 +12,18 @@ const props = defineProps<{
 
 const definition = computed<LabComponentDefinition | undefined>(() => getComponentDefinition(props.componentId))
 
-const resolvedComponentProps = ref<Record<string, unknown>>({})
-
-const handleResolvedPropsUpdate = (nextResolvedProps: Record<string, unknown>) => {
-  resolvedComponentProps.value = nextResolvedProps
-}
+const componentProps = ref<Record<string, PlaygroundPropValue>>({})
 </script>
 
 <template>
   <div v-if="definition" class="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_22rem]">
     <Preview
       :definition="definition"
-      :resolved-component-props="resolvedComponentProps"
+      :component-props="componentProps"
     />
     <Controls
       :definition="definition"
-      @update:resolved-props="handleResolvedPropsUpdate"
+      v-model:props="componentProps"
     />
   </div>
   <NotFound v-else />

--- a/playground/src/views/core/preview.vue
+++ b/playground/src/views/core/preview.vue
@@ -3,12 +3,12 @@ import { computed, defineAsyncComponent, watch } from 'vue'
 import type { AsyncComponentLoader } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Spinner from '@library/components/Spinner.vue'
-import type { LabComponentDefinition, LocaleCopy } from '@/library/catalog'
+import type { LabComponentDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/catalog'
 import type { SupportedLocale } from '@/i18n'
 
 const props = defineProps<{
   definition: LabComponentDefinition
-  resolvedComponentProps: Record<string, unknown>
+  componentProps: Record<string, PlaygroundPropValue>
 }>()
 
 const { t, locale } = useI18n()
@@ -18,12 +18,49 @@ const localize = (copy: LocaleCopy) => copy[(locale.value as SupportedLocale)] ?
 const localizedName = computed(() => localize(props.definition.name))
 const localizedDescription = computed(() => localize(props.definition.description))
 
+const resolveComponentProps = (flatProps: Record<string, PlaygroundPropValue>) => {
+  const expanded: Record<string, unknown> = {}
+
+  Object.entries(flatProps).forEach(([path, value]) => {
+    const segments = path.split('.')
+    if (segments.length === 0) {
+      return
+    }
+
+    let target: Record<string, unknown> = expanded
+    for (let index = 0; index < segments.length - 1; index += 1) {
+      const segment = segments[index]
+      if (!segment) {
+        return
+      }
+
+      const existing = target[segment]
+      if (!existing || typeof existing !== 'object' || Array.isArray(existing)) {
+        target[segment] = {}
+      }
+
+      target = target[segment] as Record<string, unknown>
+    }
+
+    const lastSegment = segments[segments.length - 1]
+    if (!lastSegment) {
+      return
+    }
+
+    target[lastSegment] = value as unknown
+  })
+
+  return expanded
+}
+
 const previewComponent = computed(() => {
   const loader = props.definition.preview ?? props.definition.component
   return defineAsyncComponent(loader as AsyncComponentLoader<any>)
 })
 
 const hasPreview = computed(() => previewComponent.value !== null)
+
+const resolvedComponentProps = computed(() => resolveComponentProps(props.componentProps))
 
 watch(
   [localizedName, () => String(t('app.title'))],


### PR DESCRIPTION
## Summary
- move component prop resolution into the preview view so previews receive nested props locally
- share component props between controls and preview via v-model binding
- simplify controls event emissions to only expose flat props

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e349da769c832c949e6e8982e28852