### PR TITLE
Use v-model binding for playground control fields

### DIFF
--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -28,6 +28,18 @@ const currentProps = reactive<Record<string, PlaygroundPropValue>>({})
 const activeControls = reactive<Record<string, boolean>>({})
 const storedOptionalValues = reactive<Record<string, PlaygroundPropValue>>({})
 
+watch(
+  currentProps,
+  () => {
+    Object.keys(currentProps).forEach((key) => {
+      if (currentProps[key] === undefined) {
+        delete currentProps[key]
+      }
+    })
+  },
+  { deep: true }
+)
+
 const controlSections = computed(() => {
   const UNGROUPED_ID = '__ungrouped__'
   const sections: { id: string; group?: ControlDefinition['group']; controls: ControlDefinition[] }[] = []
@@ -120,15 +132,6 @@ const handleOptionalToggle = (control: ControlDefinition, isActive: boolean | un
   activeControls[control.key] = checked
 }
 
-const updateControlValue = (key: string, value: PlaygroundPropValue | undefined) => {
-  if (value === undefined) {
-    delete currentProps[key]
-    return
-  }
-
-  currentProps[key] = value
-}
-
 let definitionLoadToken = 0
 
 watch(
@@ -207,11 +210,10 @@ const resetProps = () => {
             v-for="control in section.controls"
             :key="control.key"
             :control="control"
-            :value="currentProps[control.key] as PlaygroundPropValue | undefined"
+            v-model:value="(currentProps[control.key] as PlaygroundPropValue | undefined)"
             :is-optional="isControlOptional(control)"
             :is-active="isControlActive(control)"
             @toggle-optional="handleOptionalToggle(control, $event)"
-            @update:value="updateControlValue(control.key, $event)"
           />
         </Section>
         <hr


### PR DESCRIPTION
## Summary
- bind playground control fields with `v-model:value` instead of explicit update listeners
- trim undefined entries from the current control props when fields emit `undefined`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e350e89bb4832c964fbf950bc6ab27