### PR TITLE
Revert "Revert "Use v-model binding for playground control fields""

### DIFF
--- a/playground/src/views/core/controls/field.vue
+++ b/playground/src/views/core/controls/field.vue
@@ -12,13 +12,13 @@ import { toRgba } from '@shared/color'
 
 const props = defineProps<{
   control: ControlDefinition
-  value: PlaygroundPropValue | undefined
   isOptional: boolean
   isActive: boolean
 }>()
 
+const valueModel = defineModel<PlaygroundPropValue | undefined>('value')
+
 const emit = defineEmits<{
-  (event: 'update:value', value: PlaygroundPropValue | undefined): void
   (event: 'toggle-optional', value: boolean | undefined): void
 }>()
 
@@ -38,23 +38,23 @@ const toggleLabel = computed(() =>
 )
 
 const stringModel = computed<string | undefined>({
-  get: () => (typeof props.value === 'string' ? props.value : undefined),
-  set: (value) => emit('update:value', value),
+  get: () => (typeof valueModel.value === 'string' ? valueModel.value : undefined),
+  set: (value) => { valueModel.value = value },
 })
 
 const colorModel = computed<string | null>({
   get: () => toRgba(stringModel.value),
-  set: (value) => emit('update:value', value ?? ''),
+  set: (value) => { valueModel.value = value ?? '' },
 })
 
 const numberModel = computed<number | undefined>({
-  get: () => (typeof props.value === 'number' ? props.value : undefined),
-  set: (value) => emit('update:value', value),
+  get: () => (typeof valueModel.value === 'number' ? valueModel.value : undefined),
+  set: (value) => { valueModel.value = value },
 })
 
 const booleanModel = computed<boolean | undefined>({
-  get: () => (typeof props.value === 'boolean' ? props.value : undefined),
-  set: (value) => emit('update:value', value),
+  get: () => (typeof valueModel.value === 'boolean' ? valueModel.value : undefined),
+  set: (value) => { valueModel.value = value },
 })
 </script>
 

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -120,15 +120,6 @@ const handleOptionalToggle = (control: ControlDefinition, isActive: boolean | un
   activeControls[control.key] = checked
 }
 
-const updateControlValue = (key: string, value: PlaygroundPropValue | undefined) => {
-  if (value === undefined) {
-    delete currentProps[key]
-    return
-  }
-
-  currentProps[key] = value
-}
-
 let definitionLoadToken = 0
 
 watch(
@@ -207,11 +198,10 @@ const resetProps = () => {
             v-for="control in section.controls"
             :key="control.key"
             :control="control"
-            :value="currentProps[control.key] as PlaygroundPropValue | undefined"
+            v-model:value="currentProps[control.key]"
             :is-optional="isControlOptional(control)"
             :is-active="isControlActive(control)"
             @toggle-optional="handleOptionalToggle(control, $event)"
-            @update:value="updateControlValue(control.key, $event)"
           />
         </Section>
         <hr


### PR DESCRIPTION
Reverts EedoCelsius/eedocelsius.github.io#108