### PR TITLE
Fix grouping logic for playground controls

### DIFF
--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -9,31 +9,23 @@ export type PlaygroundPropValue = string | number | boolean | null | undefined
 
 export type ControlType = 'boolean' | 'slider' | 'color' | 'text' | 'textarea'
 
-export interface ControlGroupDefinition {
-  id: string
-  label: LocaleCopy
-}
-
 export interface ControlDefinition {
   key: string
   type: ControlType
   label: LocaleCopy
-  group?: ControlGroupDefinition
   helperText?: LocaleCopy
   min?: number
   max?: number
   step?: number
 }
 
-const spinnerControlGroup: ControlGroupDefinition = {
-  id: 'spinner',
-  label: { en: 'Spinner', ko: '스피너' },
+export interface GroupDefinition {
+  id: string
+  label: LocaleCopy
+  controls: ControlDefinition[]
 }
 
-const overlayControlGroup: ControlGroupDefinition = {
-  id: 'overlay',
-  label: { en: 'Overlay', ko: '오버레이' },
-}
+export type PropertyDefinition = ControlDefinition | GroupDefinition
 
 export type ComponentLoader = AsyncComponentLoader<unknown>
 
@@ -43,7 +35,7 @@ export interface LabComponentDefinition {
   description: LocaleCopy
   component: ComponentLoader
   preview?: ComponentLoader
-  controls: ControlDefinition[]
+  properties: PropertyDefinition[]
 }
 
 export const componentCatalog: LabComponentDefinition[] = [
@@ -59,7 +51,7 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@library/components/QrCode.vue'),
     preview: () => import('@/demos/QrCodeDemo.vue'),
-    controls: [
+    properties: [
       {
         key: 'lightColor',
         type: 'color',
@@ -102,7 +94,7 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@library/components/Spinner.vue'),
     preview: () => import('@/demos/SpinnerDemo.vue'),
-    controls: [
+    properties: [
       {
         key: 'diameter',
         type: 'slider',
@@ -160,7 +152,7 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@library/components/BlurOverlay.vue'),
     preview: () => import('@/demos/BlurOverlayDemo.vue'),
-    controls: [
+    properties: [
       {
         key: 'blurStrength',
         type: 'slider',
@@ -188,76 +180,79 @@ export const componentCatalog: LabComponentDefinition[] = [
     },
     component: () => import('@library/components/LoadingOverlay.vue'),
     preview: () => import('@/demos/LoadingOverlayDemo.vue'),
-    controls: [
+    properties: [
       {
-        key: 'spinner.diameter',
-        type: 'slider',
-        label: { en: 'Diameter', ko: '지름' },
-        group: spinnerControlGroup,
-        min: 32,
-        max: 160,
-        step: 4,
+        id: 'spinner',
+        label: { en: 'Spinner', ko: '스피너' },
+        controls: [
+          {
+            key: 'spinner.diameter',
+            type: 'slider',
+            label: { en: 'Diameter', ko: '지름' },
+            min: 32,
+            max: 160,
+            step: 4,
+          },
+          {
+            key: 'spinner.thickness',
+            type: 'slider',
+            label: { en: 'Ring Thickness', ko: '테두리 두께' },
+            min: 2,
+            max: 16,
+            step: 1,
+          },
+          {
+            key: 'spinner.textSize',
+            type: 'slider',
+            label: { en: 'Text Size', ko: '텍스트 크기' },
+            min: 12,
+            max: 64,
+            step: 1,
+          },
+          {
+            key: 'spinner.indicatorColor',
+            type: 'color',
+            label: { en: 'Indicator Color', ko: '인디케이터 색상' },
+          },
+          {
+            key: 'spinner.trackColor',
+            type: 'color',
+            label: { en: 'Track Color', ko: '트랙 색상' },
+          },
+          {
+            key: 'spinner.textColor',
+            type: 'color',
+            label: { en: 'Text Color', ko: '텍스트 색상' },
+          },
+          {
+            key: 'spinner.text',
+            type: 'text',
+            label: { en: 'Text', ko: '텍스트' },
+            helperText: {
+              en: 'Optional center text inside the spinner. Supports numbers or short phrases.',
+              ko: '스피너 중앙에 표시할 선택적 텍스트입니다. 숫자나 짧은 문구를 사용할 수 있습니다.',
+            },
+          },
+        ],
       },
       {
-        key: 'spinner.thickness',
-        type: 'slider',
-        label: { en: 'Ring Thickness', ko: '테두리 두께' },
-        group: spinnerControlGroup,
-        min: 2,
-        max: 16,
-        step: 1,
-      },
-      {
-        key: 'spinner.textSize',
-        type: 'slider',
-        label: { en: 'Text Size', ko: '텍스트 크기' },
-        group: spinnerControlGroup,
-        min: 12,
-        max: 64,
-        step: 1,
-      },
-      {
-        key: 'overlay.blurStrength',
-        type: 'slider',
-        label: { en: 'Blur Strength', ko: '블러 강도' },
-        group: overlayControlGroup,
-        min: 0,
-        max: 30,
-        step: 1,
-      },
-      {
-        key: 'spinner.indicatorColor',
-        type: 'color',
-        label: { en: 'Indicator Color', ko: '인디케이터 색상' },
-        group: spinnerControlGroup,
-      },
-      {
-        key: 'spinner.trackColor',
-        type: 'color',
-        label: { en: 'Track Color', ko: '트랙 색상' },
-        group: spinnerControlGroup,
-      },
-      {
-        key: 'spinner.textColor',
-        type: 'color',
-        label: { en: 'Text Color', ko: '텍스트 색상' },
-        group: spinnerControlGroup,
-      },
-      {
-        key: 'overlay.backgroundColor',
-        type: 'color',
-        label: { en: 'Background Color', ko: '배경 색상' },
-        group: overlayControlGroup,
-      },
-      {
-        key: 'spinner.text',
-        type: 'text',
-        label: { en: 'Text', ko: '텍스트' },
-        group: spinnerControlGroup,
-        helperText: {
-          en: 'Optional center text inside the spinner. Supports numbers or short phrases.',
-          ko: '스피너 중앙에 표시할 선택적 텍스트입니다. 숫자나 짧은 문구를 사용할 수 있습니다.',
-        },
+        id: 'overlay',
+        label: { en: 'Overlay', ko: '오버레이' },
+        controls: [
+          {
+            key: 'overlay.blurStrength',
+            type: 'slider',
+            label: { en: 'Blur Strength', ko: '블러 강도' },
+            min: 0,
+            max: 30,
+            step: 1,
+          },
+          {
+            key: 'overlay.backgroundColor',
+            type: 'color',
+            label: { en: 'Background Color', ko: '배경 색상' },
+          },
+        ],
       },
       {
         key: 'description',

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { ControlDefinition, LabComponentDefinition, PlaygroundPropValue } from '@/library/catalog'
+import type {
+  ControlDefinition,
+  GroupDefinition,
+  LabComponentDefinition,
+  PlaygroundPropValue,
+} from '@/library/catalog'
 import Field from './field.vue'
 import Section from './section.vue'
 
@@ -13,25 +18,29 @@ const { t } = useI18n()
 
 const componentDefaults = ref<Record<string, PlaygroundPropValue>>({})
 const demoProps = defineModel<Record<string, PlaygroundPropValue>>('props', { default: () => ({}) })
-const controlSections = computed(() => {
-  const UNGROUPED_ID = '__ungrouped__'
-  const sections: { id: string; group?: ControlDefinition['group']; controls: ControlDefinition[] }[] = []
-  const sectionMap = new Map<string, { id: string; group?: ControlDefinition['group']; controls: ControlDefinition[] }>()
+type ControlSection = { id: string; group?: GroupDefinition; controls: ControlDefinition[] }
 
-  props.definition.controls.forEach((control) => {
-    const identifier = control.group?.id ?? UNGROUPED_ID
-    let section = sectionMap.get(identifier)
-    if (!section) {
-      section = {
-        id: identifier,
-        group: control.group,
-        controls: [],
-      }
-      sectionMap.set(identifier, section)
-      sections.push(section)
+const controlSections = computed<ControlSection[]>(() => {
+  const UNGROUPED_ID = '__ungrouped__'
+  const sections: ControlSection[] = []
+  let ungroupedSection: ControlSection | undefined
+
+  props.definition.properties.forEach((property) => {
+    if ('controls' in property) {
+      sections.push({
+        id: property.id,
+        group: property,
+        controls: property.controls,
+      })
+      return
     }
 
-    section.controls.push(control)
+    if (!ungroupedSection) {
+      ungroupedSection = { id: UNGROUPED_ID, group: undefined, controls: [] }
+      sections.push(ungroupedSection)
+    }
+
+    ungroupedSection.controls.push(property)
   })
 
   return sections

--- a/playground/src/views/core/controls/section.vue
+++ b/playground/src/views/core/controls/section.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { ControlDefinition, LocaleCopy } from '@/library/catalog'
+import type { ControlDefinition, GroupDefinition, LocaleCopy } from '@/library/catalog'
 import type { SupportedLocale } from '@/i18n'
 
 const props = defineProps<{
-  section: { id: string; group?: ControlDefinition['group']; controls: ControlDefinition[] }
+  section: { id: string; group?: GroupDefinition; controls: ControlDefinition[] }
 }>()
 
 const { locale } = useI18n()


### PR DESCRIPTION
## Summary
- restore aggregation of ungrouped property definitions into a single controls section in the playground
- ensure grouped property definitions continue to render in their own sections when iterating the catalog properties

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e36fee2400832cabccb3f064cee9e5