### PR TITLE
Show control panel separator only for grouped sections

### DIFF
--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -153,7 +153,7 @@ watch(
           />
         </Section>
         <hr
-          v-if="sectionIndex < controlSections.length - 1"
+          v-if="section.group && sectionIndex < controlSections.length - 1"
           class="border-0 border-t border-surface-200/70 dark:border-surface-700/70"
         />
       </div>


### PR DESCRIPTION
## Summary
- only render the control panel separator when the section represents a grouped set of controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e37d286630832c87ee89dd8a3ff65b