### PR TITLE
Refactor playground routing updates

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -131,7 +131,7 @@ watch(
     </header>
 
     <main class="mx-auto w-full max-w-6xl px-6 pb-16 pt-10">
-      <RouterView />
+      <RouterView :key="route.fullPath" />
     </main>
   </div>
 </template>

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { onBeforeMount, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ControlDefinition, GroupDefinition, LabComponentDefinition, PlaygroundPropValue } from '@/library/catalog'
 import Field from './field.vue'
@@ -15,23 +15,21 @@ const componentDefaults = ref<Record<string, PlaygroundPropValue>>({})
 const demoProps = defineModel<Record<string, PlaygroundPropValue>>('props', { default: () => ({}) })
 type ControlSection = { id: string; group?: GroupDefinition; controls: ControlDefinition[] }
 
-const controlSections = computed<ControlSection[]>(() =>
-  props.definition.properties.map((property) => {
-    if ('controls' in property) {
-      return {
-        id: property.id,
-        group: property,
-        controls: property.controls,
-      }
-    }
-
+const controlSections = props.definition.properties.map<ControlSection>((property) => {
+  if ('controls' in property) {
     return {
-      id: property.key,
-      group: undefined,
-      controls: [property],
+      id: property.id,
+      group: property,
+      controls: property.controls,
     }
-  })
-)
+  }
+
+  return {
+    id: property.key,
+    group: undefined,
+    controls: [property],
+  }
+})
 
 const hasOwn = (object: Record<string, unknown>, key: string) => Object.prototype.hasOwnProperty.call(object, key)
 
@@ -78,54 +76,49 @@ const handleOptionalToggle = (control: ControlDefinition, isActive: boolean | un
   }
 }
 
-let definitionLoadToken = 0
+const loadComponentDefaults = async () => {
+  componentDefaults.value = {}
+  demoProps.value = {}
 
-watch(
-  () => props.definition,
-  async (nextDefinition) => {
-    const token = ++definitionLoadToken
-    componentDefaults.value = {}
-    Object.keys(demoProps.value).forEach((key) => delete demoProps.value[key])
-    const module = await nextDefinition.component()
-    if (token !== definitionLoadToken) {
+  const module = await props.definition.component()
+  const flattened: Record<string, PlaygroundPropValue> = {}
+
+  const visit = (value: unknown, path: string[]) => {
+    if (typeof value === 'function') {
+      visit((value as () => unknown)(), path)
       return
     }
-    const flattened: Record<string, PlaygroundPropValue> = {}
 
-    const visit = (value: unknown, path: string[]) => {
-      if (typeof value === 'function') {
-        visit((value as () => unknown)(), path)
-        return
-      }
-
-      if (value && typeof value === 'object' && !Array.isArray(value)) {
-        Object.entries(value as Record<string, unknown>).forEach(([key, nested]) => {
-          visit(nested, [...path, key])
-        })
-        return
-      }
-
-      if (value === undefined) {
-        return
-      }
-
-      if (path.length > 0) {
-        flattened[path.join('.')] = value as PlaygroundPropValue
-      }
-    }
-
-    const defaultsSource = (module as { defaultProps?: unknown }).defaultProps
-    if (defaultsSource && typeof defaultsSource === 'object' && !Array.isArray(defaultsSource)) {
-      Object.entries(defaultsSource as Record<string, unknown>).forEach(([key, value]) => {
-        visit(value, [key])
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.entries(value as Record<string, unknown>).forEach(([key, nested]) => {
+        visit(nested, [...path, key])
       })
+      return
     }
 
-    componentDefaults.value = flattened
-    applyDefaults()
-  },
-  { immediate: true }
-)
+    if (value === undefined) {
+      return
+    }
+
+    if (path.length > 0) {
+      flattened[path.join('.')] = value as PlaygroundPropValue
+    }
+  }
+
+  const defaultsSource = (module as { defaultProps?: unknown }).defaultProps
+  if (defaultsSource && typeof defaultsSource === 'object' && !Array.isArray(defaultsSource)) {
+    Object.entries(defaultsSource as Record<string, unknown>).forEach(([key, value]) => {
+      visit(value, [key])
+    })
+  }
+
+  componentDefaults.value = flattened
+  applyDefaults()
+}
+
+onBeforeMount(() => {
+  void loadComponentDefaults()
+})
 
 </script>
 

--- a/playground/src/views/core/index.vue
+++ b/playground/src/views/core/index.vue
@@ -18,10 +18,12 @@ const demoProps = ref<Record<string, PlaygroundPropValue>>({})
 <template>
   <div v-if="definition" class="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_22rem]">
     <Preview
+      :key="definition.id"
       :definition="definition"
       :demo-props="demoProps"
     />
     <Controls
+      :key="definition.id"
       :definition="definition"
       v-model:props="demoProps"
     />

--- a/playground/src/views/core/preview.vue
+++ b/playground/src/views/core/preview.vue
@@ -18,10 +18,7 @@ const localize = (copy: LocaleCopy) => copy[(locale.value as SupportedLocale)] ?
 const localizedName = computed(() => localize(props.definition.name))
 const localizedDescription = computed(() => localize(props.definition.description))
 
-const demoComponent = computed(() => {
-  const loader = props.definition.preview ?? props.definition.component
-  return defineAsyncComponent(loader as AsyncComponentLoader<any>)
-})
+const demoComponent = defineAsyncComponent((props.definition.preview ?? props.definition.component) as AsyncComponentLoader<any>)
 
 const resolvedDemoProps = computed(() => {
   const expanded: Record<string, unknown> = {}


### PR DESCRIPTION
## Summary
- key the router view so playground components remount when the URL changes
- reload playground control defaults during mount instead of watching definition updates
- key the preview and controls panes by definition id for consistent remounting
- precompute playground preview and control data per definition to leverage the remount behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e37fb15cac832cb218f843aca30dba