### PR TITLE
Simplify playground component loading lifecycle

### DIFF
--- a/playground/src/demos/BlurOverlayDemo.vue
+++ b/playground/src/demos/BlurOverlayDemo.vue
@@ -1,3 +1,26 @@
+<script lang="ts">
+import type { PlaygroundDemoConfig } from '@/library/types'
+
+export const playgroundDemo: PlaygroundDemoConfig = {
+  component: () => import('@library/components/BlurOverlay.vue'),
+  properties: [
+    {
+      key: 'blurStrength',
+      type: 'slider',
+      label: { en: 'Blur Strength', ko: '블러 강도' },
+      min: 0,
+      max: 30,
+      step: 1,
+    },
+    {
+      key: 'backgroundColor',
+      type: 'color',
+      label: { en: 'Background Color', ko: '배경 색상' },
+    },
+  ],
+}
+</script>
+
 <script setup lang="ts">
 import { BlurOverlay, type BlurOverlayProps } from '@library/components'
 

--- a/playground/src/demos/LoadingOverlayDemo.vue
+++ b/playground/src/demos/LoadingOverlayDemo.vue
@@ -1,3 +1,95 @@
+<script lang="ts">
+import type { PlaygroundDemoConfig } from '@/library/types'
+
+export const playgroundDemo: PlaygroundDemoConfig = {
+  component: () => import('@library/components/LoadingOverlay.vue'),
+  properties: [
+    {
+      id: 'spinner',
+      label: { en: 'Spinner', ko: '스피너' },
+      controls: [
+        {
+          key: 'spinner.diameter',
+          type: 'slider',
+          label: { en: 'Diameter', ko: '지름' },
+          min: 32,
+          max: 160,
+          step: 4,
+        },
+        {
+          key: 'spinner.thickness',
+          type: 'slider',
+          label: { en: 'Ring Thickness', ko: '테두리 두께' },
+          min: 2,
+          max: 16,
+          step: 1,
+        },
+        {
+          key: 'spinner.textSize',
+          type: 'slider',
+          label: { en: 'Text Size', ko: '텍스트 크기' },
+          min: 12,
+          max: 64,
+          step: 1,
+        },
+        {
+          key: 'spinner.indicatorColor',
+          type: 'color',
+          label: { en: 'Indicator Color', ko: '인디케이터 색상' },
+        },
+        {
+          key: 'spinner.trackColor',
+          type: 'color',
+          label: { en: 'Track Color', ko: '트랙 색상' },
+        },
+        {
+          key: 'spinner.textColor',
+          type: 'color',
+          label: { en: 'Text Color', ko: '텍스트 색상' },
+        },
+        {
+          key: 'spinner.text',
+          type: 'text',
+          label: { en: 'Text', ko: '텍스트' },
+          helperText: {
+            en: 'Optional center text inside the spinner. Supports numbers or short phrases.',
+            ko: '스피너 중앙에 표시할 선택적 텍스트입니다. 숫자나 짧은 문구를 사용할 수 있습니다.',
+          },
+        },
+      ],
+    },
+    {
+      id: 'overlay',
+      label: { en: 'Overlay', ko: '오버레이' },
+      controls: [
+        {
+          key: 'overlay.blurStrength',
+          type: 'slider',
+          label: { en: 'Blur Strength', ko: '블러 강도' },
+          min: 0,
+          max: 30,
+          step: 1,
+        },
+        {
+          key: 'overlay.backgroundColor',
+          type: 'color',
+          label: { en: 'Background Color', ko: '배경 색상' },
+        },
+      ],
+    },
+    {
+      key: 'description',
+      type: 'text',
+      label: { en: 'Description', ko: '설명' },
+      helperText: {
+        en: 'Text shown under the spinner. Leave empty to hide.',
+        ko: '스피너 아래에 표시되는 문구입니다. 비워두면 숨겨집니다.',
+      },
+    },
+  ],
+}
+</script>
+
 <script setup lang="ts">
 import { LoadingOverlay, type LoadingOverlayProps } from '@library/components'
 

--- a/playground/src/demos/QrCodeDemo.vue
+++ b/playground/src/demos/QrCodeDemo.vue
@@ -1,3 +1,41 @@
+<script lang="ts">
+import type { PlaygroundDemoConfig } from '@/library/types'
+
+export const playgroundDemo: PlaygroundDemoConfig = {
+  component: () => import('@library/components/QrCode.vue'),
+  properties: [
+    {
+      key: 'lightColor',
+      type: 'color',
+      label: { en: 'Light Color', ko: '밝은 색상' },
+    },
+    {
+      key: 'darkColor',
+      type: 'color',
+      label: { en: 'Dark Color', ko: '어두운 색상' },
+    },
+    {
+      key: 'content',
+      type: 'textarea',
+      label: { en: 'Content', ko: '콘텐츠' },
+      helperText: {
+        en: 'Text or URL that will be encoded inside the QR code.',
+        ko: 'QR 코드에 담을 텍스트 또는 URL을 입력하세요.',
+      },
+    },
+    {
+      key: 'icon',
+      type: 'text',
+      label: { en: 'Icon URL', ko: '아이콘 주소' },
+      helperText: {
+        en: 'Center image URL. Leave empty to hide the icon.',
+        ko: '중앙에 표시할 이미지 주소입니다. 비워두면 아이콘이 숨겨집니다.',
+      },
+    },
+  ],
+}
+</script>
+
 <script setup lang="ts">
 import { QrCode, type QrCodeProps } from '@library/components'
 

--- a/playground/src/demos/SpinnerDemo.vue
+++ b/playground/src/demos/SpinnerDemo.vue
@@ -1,3 +1,56 @@
+<script lang="ts">
+import type { PlaygroundDemoConfig } from '@/library/types'
+
+export const playgroundDemo: PlaygroundDemoConfig = {
+  component: () => import('@library/components/Spinner.vue'),
+  properties: [
+    {
+      key: 'diameter',
+      type: 'slider',
+      label: { en: 'Diameter', ko: '지름' },
+      min: 48,
+      max: 192,
+      step: 4,
+    },
+    {
+      key: 'thickness',
+      type: 'slider',
+      label: { en: 'Ring Thickness', ko: '테두리 두께' },
+      min: 2,
+      max: 20,
+      step: 1,
+    },
+    {
+      key: 'textSize',
+      type: 'slider',
+      label: { en: 'Text Size', ko: '텍스트 크기' },
+      min: 12,
+      max: 48,
+      step: 1,
+    },
+    {
+      key: 'indicatorColor',
+      type: 'color',
+      label: { en: 'Indicator Color', ko: '인디케이터 색상' },
+    },
+    {
+      key: 'trackColor',
+      type: 'color',
+      label: { en: 'Track Color', ko: '트랙 색상' },
+    },
+    {
+      key: 'text',
+      type: 'text',
+      label: { en: 'Text', ko: '텍스트' },
+      helperText: {
+        en: 'Content displayed at the center of the spinner.',
+        ko: '스피너 중앙에 표시할 텍스트입니다.',
+      },
+    },
+  ],
+}
+</script>
+
 <script setup lang="ts">
 import { Spinner, type SpinnerProps } from '@library/components'
 

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -1,44 +1,6 @@
-import type { AsyncComponentLoader } from 'vue'
+import type { CatalogComponent } from './types'
 
-export type LocaleCopy = {
-  en: string
-  ko: string
-}
-
-export type PlaygroundPropValue = string | number | boolean | null | undefined
-
-export type ControlType = 'boolean' | 'slider' | 'color' | 'text' | 'textarea'
-
-export interface ControlDefinition {
-  key: string
-  type: ControlType
-  label: LocaleCopy
-  helperText?: LocaleCopy
-  min?: number
-  max?: number
-  step?: number
-}
-
-export interface GroupDefinition {
-  id: string
-  label: LocaleCopy
-  controls: ControlDefinition[]
-}
-
-export type PropertyDefinition = ControlDefinition | GroupDefinition
-
-export type ComponentLoader = AsyncComponentLoader<unknown>
-
-export interface LabComponentDefinition {
-  id: string
-  name: LocaleCopy
-  description: LocaleCopy
-  component: ComponentLoader
-  preview?: ComponentLoader
-  properties: PropertyDefinition[]
-}
-
-export const componentCatalog: LabComponentDefinition[] = [
+export const componentCatalog: CatalogComponent[] = [
   {
     id: 'qr-code',
     name: {
@@ -49,38 +11,6 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Display a clean QR code with optional brand colors and a center icon.',
       ko: '브랜드 색상과 중앙 아이콘을 선택해 깔끔한 QR 코드를 보여줍니다.',
     },
-    component: () => import('@library/components/QrCode.vue'),
-    preview: () => import('@/demos/QrCodeDemo.vue'),
-    properties: [
-      {
-        key: 'lightColor',
-        type: 'color',
-        label: { en: 'Light Color', ko: '밝은 색상' },
-      },
-      {
-        key: 'darkColor',
-        type: 'color',
-        label: { en: 'Dark Color', ko: '어두운 색상' },
-      },
-      {
-        key: 'content',
-        type: 'textarea',
-        label: { en: 'Content', ko: '콘텐츠' },
-        helperText: {
-          en: 'Text or URL that will be encoded inside the QR code.',
-          ko: 'QR 코드에 담을 텍스트 또는 URL을 입력하세요.',
-        },
-      },
-      {
-        key: 'icon',
-        type: 'text',
-        label: { en: 'Icon URL', ko: '아이콘 주소' },
-        helperText: {
-          en: 'Center image URL. Leave empty to hide the icon.',
-          ko: '중앙에 표시할 이미지 주소입니다. 비워두면 아이콘이 숨겨집니다.',
-        },
-      },
-    ],
   },
   {
     id: 'spinner',
@@ -92,53 +22,6 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Animated circular spinner with optional centered text sizing.',
       ko: '중앙 텍스트 크기를 조절할 수 있는 회전형 스피너입니다.',
     },
-    component: () => import('@library/components/Spinner.vue'),
-    preview: () => import('@/demos/SpinnerDemo.vue'),
-    properties: [
-      {
-        key: 'diameter',
-        type: 'slider',
-        label: { en: 'Diameter', ko: '지름' },
-        min: 48,
-        max: 192,
-        step: 4,
-      },
-      {
-        key: 'thickness',
-        type: 'slider',
-        label: { en: 'Ring Thickness', ko: '테두리 두께' },
-        min: 2,
-        max: 20,
-        step: 1,
-      },
-      {
-        key: 'textSize',
-        type: 'slider',
-        label: { en: 'Text Size', ko: '텍스트 크기' },
-        min: 12,
-        max: 48,
-        step: 1,
-      },
-      {
-        key: 'indicatorColor',
-        type: 'color',
-        label: { en: 'Indicator Color', ko: '인디케이터 색상' },
-      },
-      {
-        key: 'trackColor',
-        type: 'color',
-        label: { en: 'Track Color', ko: '트랙 색상' },
-      },
-      {
-        key: 'text',
-        type: 'text',
-        label: { en: 'Text', ko: '텍스트' },
-        helperText: {
-          en: 'Content displayed at the center of the spinner.',
-          ko: '스피너 중앙에 표시할 텍스트입니다.',
-        },
-      },
-    ],
   },
   {
     id: 'blur-overlay',
@@ -150,23 +33,6 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Applies a configurable blur glass effect on top of any content.',
       ko: '어떤 콘텐츠든 부드러운 블러 글래스 효과로 가려줍니다.',
     },
-    component: () => import('@library/components/BlurOverlay.vue'),
-    preview: () => import('@/demos/BlurOverlayDemo.vue'),
-    properties: [
-      {
-        key: 'blurStrength',
-        type: 'slider',
-        label: { en: 'Blur Strength', ko: '블러 강도' },
-        min: 0,
-        max: 30,
-        step: 1,
-      },
-      {
-        key: 'backgroundColor',
-        type: 'color',
-        label: { en: 'Background Color', ko: '배경 색상' },
-      },
-    ],
   },
   {
     id: 'loading-overlay',
@@ -178,95 +44,9 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Displays the loading spinner with optional text and description over blurred content.',
       ko: '블러 처리된 콘텐츠 위에 로딩 스피너와 선택적인 텍스트·설명을 표시합니다.',
     },
-    component: () => import('@library/components/LoadingOverlay.vue'),
-    preview: () => import('@/demos/LoadingOverlayDemo.vue'),
-    properties: [
-      {
-        id: 'spinner',
-        label: { en: 'Spinner', ko: '스피너' },
-        controls: [
-          {
-            key: 'spinner.diameter',
-            type: 'slider',
-            label: { en: 'Diameter', ko: '지름' },
-            min: 32,
-            max: 160,
-            step: 4,
-          },
-          {
-            key: 'spinner.thickness',
-            type: 'slider',
-            label: { en: 'Ring Thickness', ko: '테두리 두께' },
-            min: 2,
-            max: 16,
-            step: 1,
-          },
-          {
-            key: 'spinner.textSize',
-            type: 'slider',
-            label: { en: 'Text Size', ko: '텍스트 크기' },
-            min: 12,
-            max: 64,
-            step: 1,
-          },
-          {
-            key: 'spinner.indicatorColor',
-            type: 'color',
-            label: { en: 'Indicator Color', ko: '인디케이터 색상' },
-          },
-          {
-            key: 'spinner.trackColor',
-            type: 'color',
-            label: { en: 'Track Color', ko: '트랙 색상' },
-          },
-          {
-            key: 'spinner.textColor',
-            type: 'color',
-            label: { en: 'Text Color', ko: '텍스트 색상' },
-          },
-          {
-            key: 'spinner.text',
-            type: 'text',
-            label: { en: 'Text', ko: '텍스트' },
-            helperText: {
-              en: 'Optional center text inside the spinner. Supports numbers or short phrases.',
-              ko: '스피너 중앙에 표시할 선택적 텍스트입니다. 숫자나 짧은 문구를 사용할 수 있습니다.',
-            },
-          },
-        ],
-      },
-      {
-        id: 'overlay',
-        label: { en: 'Overlay', ko: '오버레이' },
-        controls: [
-          {
-            key: 'overlay.blurStrength',
-            type: 'slider',
-            label: { en: 'Blur Strength', ko: '블러 강도' },
-            min: 0,
-            max: 30,
-            step: 1,
-          },
-          {
-            key: 'overlay.backgroundColor',
-            type: 'color',
-            label: { en: 'Background Color', ko: '배경 색상' },
-          },
-        ],
-      },
-      {
-        key: 'description',
-        type: 'text',
-        label: { en: 'Description', ko: '설명' },
-        helperText: {
-          en: 'Text shown under the spinner. Leave empty to hide.',
-          ko: '스피너 아래에 표시되는 문구입니다. 비워두면 숨겨집니다.',
-        },
-      },
-    ],
   },
 ]
 
-export const componentMap = new Map(componentCatalog.map((item) => [item.id, item]))
+const catalogIndex = new Map(componentCatalog.map((component) => [component.id, component]))
 
-export const getComponentDefinition = (id: string) => componentMap.get(id)
+export const findCatalogComponent = (id: string) => catalogIndex.get(id)

--- a/playground/src/library/demos.ts
+++ b/playground/src/library/demos.ts
@@ -1,0 +1,41 @@
+import type { Component } from 'vue'
+import type { PlaygroundDemoConfig, ResolvedPlaygroundDemo } from './types'
+
+type DemoModule = { default: Component; playgroundDemo?: PlaygroundDemoConfig }
+
+type DemoLoader = () => Promise<ResolvedPlaygroundDemo>
+
+const resolveDemo = async (importer: () => Promise<DemoModule>): Promise<ResolvedPlaygroundDemo> => {
+  const module = await importer()
+  const config = module.playgroundDemo
+
+  if (!config) {
+    throw new Error('Demo module is missing a playgroundDemo export')
+  }
+
+  return {
+    ...config,
+    preview: config.preview ?? (() => Promise.resolve(module.default)),
+  }
+}
+
+const demoLoaders: Record<string, DemoLoader> = {
+  'qr-code': () => resolveDemo(() => import('@/demos/QrCodeDemo.vue')),
+  spinner: () => resolveDemo(() => import('@/demos/SpinnerDemo.vue')),
+  'blur-overlay': () => resolveDemo(() => import('@/demos/BlurOverlayDemo.vue')),
+  'loading-overlay': () => resolveDemo(() => import('@/demos/LoadingOverlayDemo.vue')),
+}
+
+export const loadPlaygroundDemo = async (id: string) => {
+  const loader = demoLoaders[id]
+  if (!loader) {
+    return undefined
+  }
+
+  try {
+    return await loader()
+  } catch (error) {
+    console.error(error)
+    return undefined
+  }
+}

--- a/playground/src/library/types.ts
+++ b/playground/src/library/types.ts
@@ -1,0 +1,46 @@
+import type { AsyncComponentLoader } from 'vue'
+
+export type LocaleCopy = {
+  en: string
+  ko: string
+}
+
+export type PlaygroundPropValue = string | number | boolean | null | undefined
+
+export type ControlType = 'boolean' | 'slider' | 'color' | 'text' | 'textarea'
+
+export interface ControlDefinition {
+  key: string
+  type: ControlType
+  label: LocaleCopy
+  helperText?: LocaleCopy
+  min?: number
+  max?: number
+  step?: number
+}
+
+export interface GroupDefinition {
+  id: string
+  label: LocaleCopy
+  controls: ControlDefinition[]
+}
+
+export type PropertyDefinition = ControlDefinition | GroupDefinition
+
+export interface CatalogComponent {
+  id: string
+  name: LocaleCopy
+  description: LocaleCopy
+}
+
+export interface PlaygroundDemoConfig {
+  component: AsyncComponentLoader<unknown>
+  preview?: AsyncComponentLoader<unknown>
+  properties: PropertyDefinition[]
+}
+
+export interface ResolvedPlaygroundDemo extends PlaygroundDemoConfig {
+  preview: AsyncComponentLoader<unknown>
+}
+
+export type PlaygroundComponent = CatalogComponent & ResolvedPlaygroundDemo

--- a/playground/src/views/core/controls/field.vue
+++ b/playground/src/views/core/controls/field.vue
@@ -6,7 +6,7 @@ import InputText from 'primevue/inputtext'
 import Slider from 'primevue/slider'
 import Textarea from 'primevue/textarea'
 import { ElColorPicker } from 'element-plus'
-import type { ControlDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/catalog'
+import type { ControlDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 import { toRgba } from '@shared/color'
 

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { onBeforeMount, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { ControlDefinition, GroupDefinition, LabComponentDefinition, PlaygroundPropValue } from '@/library/catalog'
+import type { ControlDefinition, GroupDefinition, PlaygroundComponent, PlaygroundPropValue } from '@/library/types'
 import Field from './field.vue'
 import Section from './section.vue'
 
 const props = defineProps<{
-  definition: LabComponentDefinition
+  definition: PlaygroundComponent
 }>()
 
 const { t } = useI18n()

--- a/playground/src/views/core/controls/section.vue
+++ b/playground/src/views/core/controls/section.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { ControlDefinition, GroupDefinition, LocaleCopy } from '@/library/catalog'
+import type { ControlDefinition, GroupDefinition, LocaleCopy } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 
 const props = defineProps<{

--- a/playground/src/views/core/index.vue
+++ b/playground/src/views/core/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import type { LabComponentDefinition, PlaygroundPropValue } from '@/library/catalog'
-import { getComponentDefinition } from '@/library/catalog'
+import { computed, ref, shallowRef } from 'vue'
+import type { PlaygroundComponent, PlaygroundPropValue } from '@/library/types'
+import { findCatalogComponent } from '@/library/catalog'
+import { loadPlaygroundDemo } from '@/library/demos'
 import Controls from './controls/index.vue'
 import NotFound from './notFound.vue'
 import Preview from './preview.vue'
@@ -10,13 +11,27 @@ const props = defineProps<{
   componentId: string
 }>()
 
-const definition = computed<LabComponentDefinition | undefined>(() => getComponentDefinition(props.componentId))
-
+const definition = shallowRef<PlaygroundComponent | null>(null)
 const demoProps = ref<Record<string, PlaygroundPropValue>>({})
+const componentKey = computed(() => props.componentId)
+
+const entry = findCatalogComponent(componentKey.value)
+
+if (entry) {
+  const demo = await loadPlaygroundDemo(componentKey.value)
+
+  if (demo) {
+    definition.value = { ...entry, ...demo }
+  }
+}
 </script>
 
 <template>
-  <div v-if="definition" class="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_22rem]">
+  <div
+    v-if="definition"
+    :key="componentKey"
+    class="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_22rem]"
+  >
     <Preview
       :key="definition.id"
       :definition="definition"

--- a/playground/src/views/core/preview.vue
+++ b/playground/src/views/core/preview.vue
@@ -3,11 +3,11 @@ import { computed, defineAsyncComponent, watch } from 'vue'
 import type { AsyncComponentLoader } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Spinner from '@library/components/Spinner.vue'
-import type { LabComponentDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/catalog'
+import type { LocaleCopy, PlaygroundComponent, PlaygroundPropValue } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 
 const props = defineProps<{
-  definition: LabComponentDefinition
+  definition: PlaygroundComponent
   demoProps: Record<string, PlaygroundPropValue>
 }>()
 
@@ -18,7 +18,7 @@ const localize = (copy: LocaleCopy) => copy[(locale.value as SupportedLocale)] ?
 const localizedName = computed(() => localize(props.definition.name))
 const localizedDescription = computed(() => localize(props.definition.description))
 
-const demoComponent = defineAsyncComponent((props.definition.preview ?? props.definition.component) as AsyncComponentLoader<any>)
+const demoComponent = defineAsyncComponent(props.definition.preview as AsyncComponentLoader<any>)
 
 const resolvedDemoProps = computed(() => {
   const expanded: Record<string, unknown> = {}


### PR DESCRIPTION
## Summary
- remove the componentId watcher in the playground view by relying on keyed remounts
- load demos during setup with top-level await based on the current component id
- ensure the preview and controls reset together by keying the rendered layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ad72ff50832c96cdf0c9903cb334