### PR TITLE
refactor: remove unnecessary keys from playground

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -131,7 +131,7 @@ watch(
     </header>
 
     <main class="mx-auto w-full max-w-6xl px-6 pb-16 pt-10">
-      <RouterView :key="route.fullPath" />
+      <RouterView />
     </main>
   </div>
 </template>

--- a/playground/src/views/core/index.vue
+++ b/playground/src/views/core/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, shallowRef } from 'vue'
+import { ref, shallowRef } from 'vue'
 import type { PlaygroundComponent, PlaygroundPropValue } from '@/library/types'
 import { findCatalogComponent } from '@/library/catalog'
 import { loadPlaygroundDemo } from '@/library/demos'
@@ -13,12 +13,10 @@ const props = defineProps<{
 
 const definition = shallowRef<PlaygroundComponent | null>(null)
 const demoProps = ref<Record<string, PlaygroundPropValue>>({})
-const componentKey = computed(() => props.componentId)
-
-const entry = findCatalogComponent(componentKey.value)
+const entry = findCatalogComponent(props.componentId)
 
 if (entry) {
-  const demo = await loadPlaygroundDemo(componentKey.value)
+  const demo = await loadPlaygroundDemo(props.componentId)
 
   if (demo) {
     definition.value = { ...entry, ...demo }
@@ -27,21 +25,9 @@ if (entry) {
 </script>
 
 <template>
-  <div
-    v-if="definition"
-    :key="componentKey"
-    class="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_22rem]"
-  >
-    <Preview
-      :key="definition.id"
-      :definition="definition"
-      :demo-props="demoProps"
-    />
-    <Controls
-      :key="definition.id"
-      :definition="definition"
-      v-model:props="demoProps"
-    />
+  <div v-if="definition" class="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_22rem]">
+    <Preview :definition="definition" :demo-props="demoProps" />
+    <Controls :definition="definition" v-model:props="demoProps" />
   </div>
   <NotFound v-else />
 </template>


### PR DESCRIPTION
## Summary
- remove unused component key bindings in the playground views
- streamline component lookup now that the component key is gone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b48cf0cc832c875c4d923b32e385