### PR TITLE
Fix playground component reload

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -131,7 +131,9 @@ watch(
     </header>
 
     <main class="mx-auto w-full max-w-6xl px-6 pb-16 pt-10">
-      <RouterView />
+      <RouterView v-slot="{ Component, route }">
+        <component :is="Component" :key="route.fullPath" />
+      </RouterView>
     </main>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- ensure the playground view remounts when switching components so demos load correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ba3e86ec832c87978790e1147877