### PR TITLE
Refactor component catalog metadata into demo modules

### DIFF
--- a/playground/src/demos/BlurOverlayDemo.vue
+++ b/playground/src/demos/BlurOverlayDemo.vue
@@ -1,3 +1,29 @@
+<script lang="ts">
+import type { LabDemoDefinition } from '@/library/types'
+
+export const labDefinition: LabDemoDefinition = {
+  id: 'blur-overlay',
+  component: () => import('@library/components/BlurOverlay.vue'),
+  properties: [
+    {
+      key: 'blurStrength',
+      type: 'slider',
+      label: { en: 'Blur Strength', ko: '블러 강도' },
+      min: 0,
+      max: 30,
+      step: 1,
+    },
+    {
+      key: 'backgroundColor',
+      type: 'color',
+      label: { en: 'Background Color', ko: '배경 색상' },
+    },
+  ],
+}
+
+export {}
+</script>
+
 <script setup lang="ts">
 import { BlurOverlay, type BlurOverlayProps } from '@library/components'
 

--- a/playground/src/demos/LoadingOverlayDemo.vue
+++ b/playground/src/demos/LoadingOverlayDemo.vue
@@ -1,3 +1,98 @@
+<script lang="ts">
+import type { LabDemoDefinition } from '@/library/types'
+
+export const labDefinition: LabDemoDefinition = {
+  id: 'loading-overlay',
+  component: () => import('@library/components/LoadingOverlay.vue'),
+  properties: [
+    {
+      id: 'spinner',
+      label: { en: 'Spinner', ko: '스피너' },
+      controls: [
+        {
+          key: 'spinner.diameter',
+          type: 'slider',
+          label: { en: 'Diameter', ko: '지름' },
+          min: 32,
+          max: 160,
+          step: 4,
+        },
+        {
+          key: 'spinner.thickness',
+          type: 'slider',
+          label: { en: 'Ring Thickness', ko: '테두리 두께' },
+          min: 2,
+          max: 16,
+          step: 1,
+        },
+        {
+          key: 'spinner.textSize',
+          type: 'slider',
+          label: { en: 'Text Size', ko: '텍스트 크기' },
+          min: 12,
+          max: 64,
+          step: 1,
+        },
+        {
+          key: 'spinner.indicatorColor',
+          type: 'color',
+          label: { en: 'Indicator Color', ko: '인디케이터 색상' },
+        },
+        {
+          key: 'spinner.trackColor',
+          type: 'color',
+          label: { en: 'Track Color', ko: '트랙 색상' },
+        },
+        {
+          key: 'spinner.textColor',
+          type: 'color',
+          label: { en: 'Text Color', ko: '텍스트 색상' },
+        },
+        {
+          key: 'spinner.text',
+          type: 'text',
+          label: { en: 'Text', ko: '텍스트' },
+          helperText: {
+            en: 'Optional center text inside the spinner. Supports numbers or short phrases.',
+            ko: '스피너 중앙에 표시할 선택적 텍스트입니다. 숫자나 짧은 문구를 사용할 수 있습니다.',
+          },
+        },
+      ],
+    },
+    {
+      id: 'overlay',
+      label: { en: 'Overlay', ko: '오버레이' },
+      controls: [
+        {
+          key: 'overlay.blurStrength',
+          type: 'slider',
+          label: { en: 'Blur Strength', ko: '블러 강도' },
+          min: 0,
+          max: 30,
+          step: 1,
+        },
+        {
+          key: 'overlay.backgroundColor',
+          type: 'color',
+          label: { en: 'Background Color', ko: '배경 색상' },
+        },
+      ],
+    },
+    {
+      key: 'description',
+      type: 'text',
+      label: { en: 'Description', ko: '설명' },
+      helperText: {
+        en: 'Text shown under the spinner. Leave empty to hide.',
+        ko: '스피너 아래에 표시되는 문구입니다. 비워두면 숨겨집니다.',
+      },
+    },
+  ],
+}
+
+export {}
+</script>
+
 <script setup lang="ts">
 import { LoadingOverlay, type LoadingOverlayProps } from '@library/components'
 

--- a/playground/src/demos/QrCodeDemo.vue
+++ b/playground/src/demos/QrCodeDemo.vue
@@ -1,3 +1,44 @@
+<script lang="ts">
+import type { LabDemoDefinition } from '@/library/types'
+
+export const labDefinition: LabDemoDefinition = {
+  id: 'qr-code',
+  component: () => import('@library/components/QrCode.vue'),
+  properties: [
+    {
+      key: 'lightColor',
+      type: 'color',
+      label: { en: 'Light Color', ko: '밝은 색상' },
+    },
+    {
+      key: 'darkColor',
+      type: 'color',
+      label: { en: 'Dark Color', ko: '어두운 색상' },
+    },
+    {
+      key: 'content',
+      type: 'textarea',
+      label: { en: 'Content', ko: '콘텐츠' },
+      helperText: {
+        en: 'Text or URL that will be encoded inside the QR code.',
+        ko: 'QR 코드에 담을 텍스트 또는 URL을 입력하세요.',
+      },
+    },
+    {
+      key: 'icon',
+      type: 'text',
+      label: { en: 'Icon URL', ko: '아이콘 주소' },
+      helperText: {
+        en: 'Center image URL. Leave empty to hide the icon.',
+        ko: '중앙에 표시할 이미지 주소입니다. 비워두면 아이콘이 숨겨집니다.',
+      },
+    },
+  ],
+}
+
+export {}
+</script>
+
 <script setup lang="ts">
 import { QrCode, type QrCodeProps } from '@library/components'
 

--- a/playground/src/demos/SpinnerDemo.vue
+++ b/playground/src/demos/SpinnerDemo.vue
@@ -1,3 +1,59 @@
+<script lang="ts">
+import type { LabDemoDefinition } from '@/library/types'
+
+export const labDefinition: LabDemoDefinition = {
+  id: 'spinner',
+  component: () => import('@library/components/Spinner.vue'),
+  properties: [
+    {
+      key: 'diameter',
+      type: 'slider',
+      label: { en: 'Diameter', ko: '지름' },
+      min: 48,
+      max: 192,
+      step: 4,
+    },
+    {
+      key: 'thickness',
+      type: 'slider',
+      label: { en: 'Ring Thickness', ko: '테두리 두께' },
+      min: 2,
+      max: 20,
+      step: 1,
+    },
+    {
+      key: 'textSize',
+      type: 'slider',
+      label: { en: 'Text Size', ko: '텍스트 크기' },
+      min: 12,
+      max: 48,
+      step: 1,
+    },
+    {
+      key: 'indicatorColor',
+      type: 'color',
+      label: { en: 'Indicator Color', ko: '인디케이터 색상' },
+    },
+    {
+      key: 'trackColor',
+      type: 'color',
+      label: { en: 'Track Color', ko: '트랙 색상' },
+    },
+    {
+      key: 'text',
+      type: 'text',
+      label: { en: 'Text', ko: '텍스트' },
+      helperText: {
+        en: 'Content displayed at the center of the spinner.',
+        ko: '스피너 중앙에 표시할 텍스트입니다.',
+      },
+    },
+  ],
+}
+
+export {}
+</script>
+
 <script setup lang="ts">
 import { Spinner, type SpinnerProps } from '@library/components'
 

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -1,44 +1,18 @@
-import type { AsyncComponentLoader } from 'vue'
+import type { LabDemoDefinition, CatalogComponent, LabComponentDefinition, ComponentLoader } from './types'
 
-export type LocaleCopy = {
-  en: string
-  ko: string
-}
+export type {
+  LocaleCopy,
+  PlaygroundPropValue,
+  ControlDefinition,
+  GroupDefinition,
+  PropertyDefinition,
+  ComponentLoader,
+  CatalogComponent,
+  LabDemoDefinition,
+  LabComponentDefinition,
+} from './types'
 
-export type PlaygroundPropValue = string | number | boolean | null | undefined
-
-export type ControlType = 'boolean' | 'slider' | 'color' | 'text' | 'textarea'
-
-export interface ControlDefinition {
-  key: string
-  type: ControlType
-  label: LocaleCopy
-  helperText?: LocaleCopy
-  min?: number
-  max?: number
-  step?: number
-}
-
-export interface GroupDefinition {
-  id: string
-  label: LocaleCopy
-  controls: ControlDefinition[]
-}
-
-export type PropertyDefinition = ControlDefinition | GroupDefinition
-
-export type ComponentLoader = AsyncComponentLoader<unknown>
-
-export interface LabComponentDefinition {
-  id: string
-  name: LocaleCopy
-  description: LocaleCopy
-  component: ComponentLoader
-  preview?: ComponentLoader
-  properties: PropertyDefinition[]
-}
-
-export const componentCatalog: LabComponentDefinition[] = [
+export const componentCatalog: CatalogComponent[] = [
   {
     id: 'qr-code',
     name: {
@@ -49,38 +23,6 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Display a clean QR code with optional brand colors and a center icon.',
       ko: '브랜드 색상과 중앙 아이콘을 선택해 깔끔한 QR 코드를 보여줍니다.',
     },
-    component: () => import('@library/components/QrCode.vue'),
-    preview: () => import('@/demos/QrCodeDemo.vue'),
-    properties: [
-      {
-        key: 'lightColor',
-        type: 'color',
-        label: { en: 'Light Color', ko: '밝은 색상' },
-      },
-      {
-        key: 'darkColor',
-        type: 'color',
-        label: { en: 'Dark Color', ko: '어두운 색상' },
-      },
-      {
-        key: 'content',
-        type: 'textarea',
-        label: { en: 'Content', ko: '콘텐츠' },
-        helperText: {
-          en: 'Text or URL that will be encoded inside the QR code.',
-          ko: 'QR 코드에 담을 텍스트 또는 URL을 입력하세요.',
-        },
-      },
-      {
-        key: 'icon',
-        type: 'text',
-        label: { en: 'Icon URL', ko: '아이콘 주소' },
-        helperText: {
-          en: 'Center image URL. Leave empty to hide the icon.',
-          ko: '중앙에 표시할 이미지 주소입니다. 비워두면 아이콘이 숨겨집니다.',
-        },
-      },
-    ],
   },
   {
     id: 'spinner',
@@ -92,53 +34,6 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Animated circular spinner with optional centered text sizing.',
       ko: '중앙 텍스트 크기를 조절할 수 있는 회전형 스피너입니다.',
     },
-    component: () => import('@library/components/Spinner.vue'),
-    preview: () => import('@/demos/SpinnerDemo.vue'),
-    properties: [
-      {
-        key: 'diameter',
-        type: 'slider',
-        label: { en: 'Diameter', ko: '지름' },
-        min: 48,
-        max: 192,
-        step: 4,
-      },
-      {
-        key: 'thickness',
-        type: 'slider',
-        label: { en: 'Ring Thickness', ko: '테두리 두께' },
-        min: 2,
-        max: 20,
-        step: 1,
-      },
-      {
-        key: 'textSize',
-        type: 'slider',
-        label: { en: 'Text Size', ko: '텍스트 크기' },
-        min: 12,
-        max: 48,
-        step: 1,
-      },
-      {
-        key: 'indicatorColor',
-        type: 'color',
-        label: { en: 'Indicator Color', ko: '인디케이터 색상' },
-      },
-      {
-        key: 'trackColor',
-        type: 'color',
-        label: { en: 'Track Color', ko: '트랙 색상' },
-      },
-      {
-        key: 'text',
-        type: 'text',
-        label: { en: 'Text', ko: '텍스트' },
-        helperText: {
-          en: 'Content displayed at the center of the spinner.',
-          ko: '스피너 중앙에 표시할 텍스트입니다.',
-        },
-      },
-    ],
   },
   {
     id: 'blur-overlay',
@@ -150,23 +45,6 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Applies a configurable blur glass effect on top of any content.',
       ko: '어떤 콘텐츠든 부드러운 블러 글래스 효과로 가려줍니다.',
     },
-    component: () => import('@library/components/BlurOverlay.vue'),
-    preview: () => import('@/demos/BlurOverlayDemo.vue'),
-    properties: [
-      {
-        key: 'blurStrength',
-        type: 'slider',
-        label: { en: 'Blur Strength', ko: '블러 강도' },
-        min: 0,
-        max: 30,
-        step: 1,
-      },
-      {
-        key: 'backgroundColor',
-        type: 'color',
-        label: { en: 'Background Color', ko: '배경 색상' },
-      },
-    ],
   },
   {
     id: 'loading-overlay',
@@ -178,95 +56,51 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Displays the loading spinner with optional text and description over blurred content.',
       ko: '블러 처리된 콘텐츠 위에 로딩 스피너와 선택적인 텍스트·설명을 표시합니다.',
     },
-    component: () => import('@library/components/LoadingOverlay.vue'),
-    preview: () => import('@/demos/LoadingOverlayDemo.vue'),
-    properties: [
-      {
-        id: 'spinner',
-        label: { en: 'Spinner', ko: '스피너' },
-        controls: [
-          {
-            key: 'spinner.diameter',
-            type: 'slider',
-            label: { en: 'Diameter', ko: '지름' },
-            min: 32,
-            max: 160,
-            step: 4,
-          },
-          {
-            key: 'spinner.thickness',
-            type: 'slider',
-            label: { en: 'Ring Thickness', ko: '테두리 두께' },
-            min: 2,
-            max: 16,
-            step: 1,
-          },
-          {
-            key: 'spinner.textSize',
-            type: 'slider',
-            label: { en: 'Text Size', ko: '텍스트 크기' },
-            min: 12,
-            max: 64,
-            step: 1,
-          },
-          {
-            key: 'spinner.indicatorColor',
-            type: 'color',
-            label: { en: 'Indicator Color', ko: '인디케이터 색상' },
-          },
-          {
-            key: 'spinner.trackColor',
-            type: 'color',
-            label: { en: 'Track Color', ko: '트랙 색상' },
-          },
-          {
-            key: 'spinner.textColor',
-            type: 'color',
-            label: { en: 'Text Color', ko: '텍스트 색상' },
-          },
-          {
-            key: 'spinner.text',
-            type: 'text',
-            label: { en: 'Text', ko: '텍스트' },
-            helperText: {
-              en: 'Optional center text inside the spinner. Supports numbers or short phrases.',
-              ko: '스피너 중앙에 표시할 선택적 텍스트입니다. 숫자나 짧은 문구를 사용할 수 있습니다.',
-            },
-          },
-        ],
-      },
-      {
-        id: 'overlay',
-        label: { en: 'Overlay', ko: '오버레이' },
-        controls: [
-          {
-            key: 'overlay.blurStrength',
-            type: 'slider',
-            label: { en: 'Blur Strength', ko: '블러 강도' },
-            min: 0,
-            max: 30,
-            step: 1,
-          },
-          {
-            key: 'overlay.backgroundColor',
-            type: 'color',
-            label: { en: 'Background Color', ko: '배경 색상' },
-          },
-        ],
-      },
-      {
-        key: 'description',
-        type: 'text',
-        label: { en: 'Description', ko: '설명' },
-        helperText: {
-          en: 'Text shown under the spinner. Leave empty to hide.',
-          ko: '스피너 아래에 표시되는 문구입니다. 비워두면 숨겨집니다.',
-        },
-      },
-    ],
   },
 ]
 
-export const componentMap = new Map(componentCatalog.map((item) => [item.id, item]))
+type DemoModule = {
+  default: unknown
+  labDefinition?: LabDemoDefinition
+}
+
+const toAsyncComponent = (component: unknown): ComponentLoader => async () => component
+
+const demoModules = import.meta.glob('../demos/*Demo.vue', { eager: true }) as Record<string, DemoModule>
+
+const demoDefinitions = new Map<string, LabDemoDefinition & { preview: ComponentLoader }>()
+
+Object.entries(demoModules).forEach(([path, module]) => {
+  const definition = module.labDefinition
+  if (!definition) {
+    throw new Error(`Demo module at "${path}" must export labDefinition`)
+  }
+
+  const previewLoader = definition.preview ?? toAsyncComponent(module.default)
+
+  demoDefinitions.set(definition.id, {
+    ...definition,
+    preview: previewLoader,
+  })
+})
+
+const componentDefinitions: LabComponentDefinition[] = componentCatalog.map((component) => {
+  const demoDefinition = demoDefinitions.get(component.id)
+
+  if (!demoDefinition) {
+    throw new Error(`Missing demo definition for component id: ${component.id}`)
+  }
+
+  return {
+    ...component,
+    component: demoDefinition.component,
+    preview: demoDefinition.preview,
+    properties: demoDefinition.properties,
+  }
+})
+
+const componentMap = new Map(componentDefinitions.map((definition) => [definition.id, definition] as const))
 
 export const getComponentDefinition = (id: string) => componentMap.get(id)
+
+export { componentDefinitions }

--- a/playground/src/library/types.ts
+++ b/playground/src/library/types.ts
@@ -1,0 +1,49 @@
+import type { AsyncComponentLoader } from 'vue'
+
+export type LocaleCopy = {
+  en: string
+  ko: string
+}
+
+export type PlaygroundPropValue = string | number | boolean | null | undefined
+
+export type ControlType = 'boolean' | 'slider' | 'color' | 'text' | 'textarea'
+
+export interface ControlDefinition {
+  key: string
+  type: ControlType
+  label: LocaleCopy
+  helperText?: LocaleCopy
+  min?: number
+  max?: number
+  step?: number
+}
+
+export interface GroupDefinition {
+  id: string
+  label: LocaleCopy
+  controls: ControlDefinition[]
+}
+
+export type PropertyDefinition = ControlDefinition | GroupDefinition
+
+export type ComponentLoader = AsyncComponentLoader<unknown>
+
+export interface CatalogComponent {
+  id: string
+  name: LocaleCopy
+  description: LocaleCopy
+}
+
+export interface LabDemoDefinition {
+  id: string
+  component: ComponentLoader
+  properties: PropertyDefinition[]
+  preview?: ComponentLoader
+}
+
+export interface LabComponentDefinition extends CatalogComponent {
+  component: ComponentLoader
+  preview: ComponentLoader
+  properties: PropertyDefinition[]
+}


### PR DESCRIPTION
## Summary
- add shared playground type definitions and streamline the catalog to core metadata only
- load component playground definitions from each demo module instead of the catalog
- embed per-component control metadata inside the corresponding demo components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3bf5e5a84832c9bffedbcf7f83667