### PR TITLE
Refactor catalog metadata into demo modules

### DIFF
--- a/playground/src/demos/BlurOverlayDemo.vue
+++ b/playground/src/demos/BlurOverlayDemo.vue
@@ -1,3 +1,27 @@
+<script lang="ts">
+import { defaultProps as blurOverlayDefaults } from '@library/components/BlurOverlay.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: blurOverlayDefaults,
+  properties: [
+    {
+      key: 'blurStrength',
+      type: 'slider',
+      label: { en: 'Blur Strength', ko: '블러 강도' },
+      min: 0,
+      max: 30,
+      step: 1,
+    },
+    {
+      key: 'backgroundColor',
+      type: 'color',
+      label: { en: 'Background Color', ko: '배경 색상' },
+    },
+  ],
+}
+</script>
+
 <script setup lang="ts">
 import { BlurOverlay, type BlurOverlayProps } from '@library/components'
 
@@ -5,22 +29,20 @@ defineProps<BlurOverlayProps>()
 </script>
 
 <template>
-  <div class="relative block overflow-hidden rounded-3xl shadow-soft">
-    <div class="h-64 w-full bg-gradient-to-br from-primary-500 via-surface-900 to-surface-800">
-      <div class="flex h-full flex-col justify-between p-8 text-surface-0">
-        <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.4em] text-surface-0/60">Creative focus</p>
-          <h3 class="mt-4 text-3xl font-semibold">Aurora Session</h3>
-        </div>
-        <p class="max-w-sm text-sm text-surface-0/70">
-          Overlay sections help draw attention while keeping the page context visible beneath.
-        </p>
-      </div>
-    </div>
+  <div class="relative isolate flex h-80 items-center justify-center overflow-hidden rounded-3xl border border-surface-200 bg-surface-0 p-10 text-center shadow-inner dark:border-surface-800 dark:bg-surface-900">
+    <img
+      src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1000&q=80"
+      alt="Developer workspace"
+      class="absolute inset-0 h-full w-full object-cover"
+    />
     <BlurOverlay v-bind="$props">
       <template #overlay>
-        <div class="rounded-full bg-surface-0/20 px-6 py-3 text-xs font-semibold uppercase tracking-[0.4em] text-surface-0/90">
-          Overlay Active
+        <div class="flex max-w-sm flex-col items-center gap-3 text-surface-0">
+          <span class="text-xs font-semibold uppercase tracking-[0.4em] text-primary-300">Focus Mode</span>
+          <h2 class="text-2xl font-semibold">Shipping polished experiences</h2>
+          <p class="text-sm text-surface-0/80">
+            Blur surrounding distractions while presenting a focused call-to-action for your customers.
+          </p>
         </div>
       </template>
     </BlurOverlay>

--- a/playground/src/demos/LoadingOverlayDemo.vue
+++ b/playground/src/demos/LoadingOverlayDemo.vue
@@ -1,3 +1,96 @@
+<script lang="ts">
+import { defaultProps as loadingOverlayDefaults } from '@library/components/LoadingOverlay.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: loadingOverlayDefaults,
+  properties: [
+    {
+      id: 'spinner',
+      label: { en: 'Spinner', ko: '스피너' },
+      controls: [
+        {
+          key: 'spinner.diameter',
+          type: 'slider',
+          label: { en: 'Diameter', ko: '지름' },
+          min: 32,
+          max: 160,
+          step: 4,
+        },
+        {
+          key: 'spinner.thickness',
+          type: 'slider',
+          label: { en: 'Ring Thickness', ko: '테두리 두께' },
+          min: 2,
+          max: 16,
+          step: 1,
+        },
+        {
+          key: 'spinner.textSize',
+          type: 'slider',
+          label: { en: 'Text Size', ko: '텍스트 크기' },
+          min: 12,
+          max: 64,
+          step: 1,
+        },
+        {
+          key: 'spinner.indicatorColor',
+          type: 'color',
+          label: { en: 'Indicator Color', ko: '인디케이터 색상' },
+        },
+        {
+          key: 'spinner.trackColor',
+          type: 'color',
+          label: { en: 'Track Color', ko: '트랙 색상' },
+        },
+        {
+          key: 'spinner.textColor',
+          type: 'color',
+          label: { en: 'Text Color', ko: '텍스트 색상' },
+        },
+        {
+          key: 'spinner.text',
+          type: 'text',
+          label: { en: 'Text', ko: '텍스트' },
+          helperText: {
+            en: 'Optional center text inside the spinner. Supports numbers or short phrases.',
+            ko: '스피너 중앙에 표시할 선택적 텍스트입니다. 숫자나 짧은 문구를 사용할 수 있습니다.',
+          },
+        },
+      ],
+    },
+    {
+      id: 'overlay',
+      label: { en: 'Overlay', ko: '오버레이' },
+      controls: [
+        {
+          key: 'overlay.blurStrength',
+          type: 'slider',
+          label: { en: 'Blur Strength', ko: '블러 강도' },
+          min: 0,
+          max: 30,
+          step: 1,
+        },
+        {
+          key: 'overlay.backgroundColor',
+          type: 'color',
+          label: { en: 'Background Color', ko: '배경 색상' },
+        },
+      ],
+    },
+    {
+      key: 'description',
+      type: 'text',
+      label: { en: 'Description', ko: '설명' },
+      helperText: {
+        en: 'Text shown under the spinner. Leave empty to hide.',
+        ko: '스피너 아래에 표시되는 문구입니다. 비워두면 숨겨집니다.',
+      },
+    },
+  ],
+}
+</script>
+
 <script setup lang="ts">
 import { LoadingOverlay, type LoadingOverlayProps } from '@library/components'
 
@@ -5,31 +98,16 @@ defineProps<LoadingOverlayProps>()
 </script>
 
 <template>
-  <LoadingOverlay v-bind="$props" class="block overflow-hidden rounded-3xl shadow-soft">
-    <div class="grid h-64 w-full gap-6 bg-surface-0 p-8 text-surface-800 dark:bg-surface-900 dark:text-surface-0 md:grid-cols-2">
-      <section class="flex flex-col justify-between rounded-2xl border border-surface-200/70 bg-surface-50/70 p-5 dark:border-surface-800/70 dark:bg-surface-800/50">
-        <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.4em] text-primary-500">Sprint focus</p>
-          <h3 class="mt-3 text-2xl font-semibold">Dashboard revamp</h3>
-        </div>
-        <p class="text-sm text-surface-600 dark:text-surface-300">
-          Current iteration tackles responsive layouts and loading experiences for the analytics hub.
-        </p>
-      </section>
-      <section class="flex flex-col justify-between rounded-2xl border border-surface-200/70 bg-surface-50/70 p-5 dark:border-surface-800/70 dark:bg-surface-800/50">
-        <div class="flex items-center justify-between text-sm font-medium">
-          <span>Wireframes</span>
-          <span class="text-primary-500">100%</span>
-        </div>
-        <div class="flex items-center justify-between text-sm font-medium">
-          <span>API integration</span>
-          <span class="text-primary-500">70%</span>
-        </div>
-        <div class="flex items-center justify-between text-sm font-medium">
-          <span>QA checklist</span>
-          <span class="text-primary-500">45%</span>
-        </div>
-      </section>
-    </div>
-  </LoadingOverlay>
+  <div class="relative h-80 overflow-hidden rounded-3xl border border-surface-200 bg-surface-0 shadow-inner dark:border-surface-800 dark:bg-surface-900">
+    <img
+      src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1000&q=80"
+      alt="Project dashboard"
+      class="absolute inset-0 h-full w-full object-cover"
+    />
+    <LoadingOverlay v-bind="$props" class="absolute inset-0">
+      <template #default>
+        <div class="pointer-events-none absolute inset-0 bg-gradient-to-br from-surface-900/50 via-surface-900/20 to-surface-900/70" />
+      </template>
+    </LoadingOverlay>
+  </div>
 </template>

--- a/playground/src/demos/QrCodeDemo.vue
+++ b/playground/src/demos/QrCodeDemo.vue
@@ -1,3 +1,42 @@
+<script lang="ts">
+import { defaultProps as qrCodeDefaults } from '@library/components/QrCode.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: qrCodeDefaults,
+  properties: [
+    {
+      key: 'lightColor',
+      type: 'color',
+      label: { en: 'Light Color', ko: '밝은 색상' },
+    },
+    {
+      key: 'darkColor',
+      type: 'color',
+      label: { en: 'Dark Color', ko: '어두운 색상' },
+    },
+    {
+      key: 'content',
+      type: 'textarea',
+      label: { en: 'Content', ko: '콘텐츠' },
+      helperText: {
+        en: 'Text or URL that will be encoded inside the QR code.',
+        ko: 'QR 코드에 담을 텍스트 또는 URL을 입력하세요.',
+      },
+    },
+    {
+      key: 'icon',
+      type: 'text',
+      label: { en: 'Icon URL', ko: '아이콘 주소' },
+      helperText: {
+        en: 'Center image URL. Leave empty to hide the icon.',
+        ko: '중앙에 표시할 이미지 주소입니다. 비워두면 아이콘이 숨겨집니다.',
+      },
+    },
+  ],
+}
+</script>
+
 <script setup lang="ts">
 import { QrCode, type QrCodeProps } from '@library/components'
 

--- a/playground/src/demos/SpinnerDemo.vue
+++ b/playground/src/demos/SpinnerDemo.vue
@@ -1,3 +1,57 @@
+<script lang="ts">
+import { defaultProps as spinnerDefaults } from '@library/components/Spinner.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: spinnerDefaults,
+  properties: [
+    {
+      key: 'diameter',
+      type: 'slider',
+      label: { en: 'Diameter', ko: '지름' },
+      min: 48,
+      max: 192,
+      step: 4,
+    },
+    {
+      key: 'thickness',
+      type: 'slider',
+      label: { en: 'Ring Thickness', ko: '테두리 두께' },
+      min: 2,
+      max: 20,
+      step: 1,
+    },
+    {
+      key: 'textSize',
+      type: 'slider',
+      label: { en: 'Text Size', ko: '텍스트 크기' },
+      min: 12,
+      max: 48,
+      step: 1,
+    },
+    {
+      key: 'indicatorColor',
+      type: 'color',
+      label: { en: 'Indicator Color', ko: '인디케이터 색상' },
+    },
+    {
+      key: 'trackColor',
+      type: 'color',
+      label: { en: 'Track Color', ko: '트랙 색상' },
+    },
+    {
+      key: 'text',
+      type: 'text',
+      label: { en: 'Text', ko: '텍스트' },
+      helperText: {
+        en: 'Content displayed at the center of the spinner.',
+        ko: '스피너 중앙에 표시할 텍스트입니다.',
+      },
+    },
+  ],
+}
+</script>
+
 <script setup lang="ts">
 import { Spinner, type SpinnerProps } from '@library/components'
 
@@ -5,12 +59,7 @@ defineProps<SpinnerProps>()
 </script>
 
 <template>
-  <div class="grid gap-6 rounded-3xl bg-surface-0 p-8 text-surface-800 shadow-soft dark:bg-surface-900 dark:text-surface-0">
-    <div class="flex flex-col items-center gap-4 text-center">
-      <Spinner v-bind="$props" />
-      <p class="text-sm text-surface-600 dark:text-surface-300">
-        Tune the animated spinner to match your loading experience.
-      </p>
-    </div>
+  <div class="flex justify-center">
+    <Spinner v-bind="$props" />
   </div>
 </template>

--- a/playground/src/demos/index.ts
+++ b/playground/src/demos/index.ts
@@ -1,0 +1,28 @@
+import BlurOverlayDemo, { demoConfig as blurOverlayConfig } from './BlurOverlayDemo.vue'
+import LoadingOverlayDemo, { demoConfig as loadingOverlayConfig } from './LoadingOverlayDemo.vue'
+import QrCodeDemo, { demoConfig as qrCodeConfig } from './QrCodeDemo.vue'
+import SpinnerDemo, { demoConfig as spinnerConfig } from './SpinnerDemo.vue'
+import type { ComponentDemo } from './types'
+
+const demoEntries: Record<string, ComponentDemo> = {
+  'blur-overlay': {
+    component: BlurOverlayDemo,
+    ...blurOverlayConfig,
+  },
+  'loading-overlay': {
+    component: LoadingOverlayDemo,
+    ...loadingOverlayConfig,
+  },
+  'qr-code': {
+    component: QrCodeDemo,
+    ...qrCodeConfig,
+  },
+  spinner: {
+    component: SpinnerDemo,
+    ...spinnerConfig,
+  },
+}
+
+export const componentDemos = demoEntries
+
+export const getComponentDemo = (id: string) => componentDemos[id]

--- a/playground/src/demos/types.ts
+++ b/playground/src/demos/types.ts
@@ -1,0 +1,11 @@
+import type { Component } from 'vue'
+import type { PropertyDefinition } from '@/library/types'
+
+export interface ComponentDemoConfig {
+  properties: PropertyDefinition[]
+  defaultProps?: Record<string, unknown>
+}
+
+export interface ComponentDemo extends ComponentDemoConfig {
+  component: Component
+}

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -1,44 +1,12 @@
-import type { AsyncComponentLoader } from 'vue'
+import type { LocaleCopy } from './types'
 
-export type LocaleCopy = {
-  en: string
-  ko: string
-}
-
-export type PlaygroundPropValue = string | number | boolean | null | undefined
-
-export type ControlType = 'boolean' | 'slider' | 'color' | 'text' | 'textarea'
-
-export interface ControlDefinition {
-  key: string
-  type: ControlType
-  label: LocaleCopy
-  helperText?: LocaleCopy
-  min?: number
-  max?: number
-  step?: number
-}
-
-export interface GroupDefinition {
-  id: string
-  label: LocaleCopy
-  controls: ControlDefinition[]
-}
-
-export type PropertyDefinition = ControlDefinition | GroupDefinition
-
-export type ComponentLoader = AsyncComponentLoader<unknown>
-
-export interface LabComponentDefinition {
+export interface LabComponentSummary {
   id: string
   name: LocaleCopy
   description: LocaleCopy
-  component: ComponentLoader
-  preview?: ComponentLoader
-  properties: PropertyDefinition[]
 }
 
-export const componentCatalog: LabComponentDefinition[] = [
+export const componentCatalog: LabComponentSummary[] = [
   {
     id: 'qr-code',
     name: {
@@ -49,38 +17,6 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Display a clean QR code with optional brand colors and a center icon.',
       ko: '브랜드 색상과 중앙 아이콘을 선택해 깔끔한 QR 코드를 보여줍니다.',
     },
-    component: () => import('@library/components/QrCode.vue'),
-    preview: () => import('@/demos/QrCodeDemo.vue'),
-    properties: [
-      {
-        key: 'lightColor',
-        type: 'color',
-        label: { en: 'Light Color', ko: '밝은 색상' },
-      },
-      {
-        key: 'darkColor',
-        type: 'color',
-        label: { en: 'Dark Color', ko: '어두운 색상' },
-      },
-      {
-        key: 'content',
-        type: 'textarea',
-        label: { en: 'Content', ko: '콘텐츠' },
-        helperText: {
-          en: 'Text or URL that will be encoded inside the QR code.',
-          ko: 'QR 코드에 담을 텍스트 또는 URL을 입력하세요.',
-        },
-      },
-      {
-        key: 'icon',
-        type: 'text',
-        label: { en: 'Icon URL', ko: '아이콘 주소' },
-        helperText: {
-          en: 'Center image URL. Leave empty to hide the icon.',
-          ko: '중앙에 표시할 이미지 주소입니다. 비워두면 아이콘이 숨겨집니다.',
-        },
-      },
-    ],
   },
   {
     id: 'spinner',
@@ -92,53 +28,6 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Animated circular spinner with optional centered text sizing.',
       ko: '중앙 텍스트 크기를 조절할 수 있는 회전형 스피너입니다.',
     },
-    component: () => import('@library/components/Spinner.vue'),
-    preview: () => import('@/demos/SpinnerDemo.vue'),
-    properties: [
-      {
-        key: 'diameter',
-        type: 'slider',
-        label: { en: 'Diameter', ko: '지름' },
-        min: 48,
-        max: 192,
-        step: 4,
-      },
-      {
-        key: 'thickness',
-        type: 'slider',
-        label: { en: 'Ring Thickness', ko: '테두리 두께' },
-        min: 2,
-        max: 20,
-        step: 1,
-      },
-      {
-        key: 'textSize',
-        type: 'slider',
-        label: { en: 'Text Size', ko: '텍스트 크기' },
-        min: 12,
-        max: 48,
-        step: 1,
-      },
-      {
-        key: 'indicatorColor',
-        type: 'color',
-        label: { en: 'Indicator Color', ko: '인디케이터 색상' },
-      },
-      {
-        key: 'trackColor',
-        type: 'color',
-        label: { en: 'Track Color', ko: '트랙 색상' },
-      },
-      {
-        key: 'text',
-        type: 'text',
-        label: { en: 'Text', ko: '텍스트' },
-        helperText: {
-          en: 'Content displayed at the center of the spinner.',
-          ko: '스피너 중앙에 표시할 텍스트입니다.',
-        },
-      },
-    ],
   },
   {
     id: 'blur-overlay',
@@ -150,23 +39,6 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Applies a configurable blur glass effect on top of any content.',
       ko: '어떤 콘텐츠든 부드러운 블러 글래스 효과로 가려줍니다.',
     },
-    component: () => import('@library/components/BlurOverlay.vue'),
-    preview: () => import('@/demos/BlurOverlayDemo.vue'),
-    properties: [
-      {
-        key: 'blurStrength',
-        type: 'slider',
-        label: { en: 'Blur Strength', ko: '블러 강도' },
-        min: 0,
-        max: 30,
-        step: 1,
-      },
-      {
-        key: 'backgroundColor',
-        type: 'color',
-        label: { en: 'Background Color', ko: '배경 색상' },
-      },
-    ],
   },
   {
     id: 'loading-overlay',
@@ -178,95 +50,9 @@ export const componentCatalog: LabComponentDefinition[] = [
       en: 'Displays the loading spinner with optional text and description over blurred content.',
       ko: '블러 처리된 콘텐츠 위에 로딩 스피너와 선택적인 텍스트·설명을 표시합니다.',
     },
-    component: () => import('@library/components/LoadingOverlay.vue'),
-    preview: () => import('@/demos/LoadingOverlayDemo.vue'),
-    properties: [
-      {
-        id: 'spinner',
-        label: { en: 'Spinner', ko: '스피너' },
-        controls: [
-          {
-            key: 'spinner.diameter',
-            type: 'slider',
-            label: { en: 'Diameter', ko: '지름' },
-            min: 32,
-            max: 160,
-            step: 4,
-          },
-          {
-            key: 'spinner.thickness',
-            type: 'slider',
-            label: { en: 'Ring Thickness', ko: '테두리 두께' },
-            min: 2,
-            max: 16,
-            step: 1,
-          },
-          {
-            key: 'spinner.textSize',
-            type: 'slider',
-            label: { en: 'Text Size', ko: '텍스트 크기' },
-            min: 12,
-            max: 64,
-            step: 1,
-          },
-          {
-            key: 'spinner.indicatorColor',
-            type: 'color',
-            label: { en: 'Indicator Color', ko: '인디케이터 색상' },
-          },
-          {
-            key: 'spinner.trackColor',
-            type: 'color',
-            label: { en: 'Track Color', ko: '트랙 색상' },
-          },
-          {
-            key: 'spinner.textColor',
-            type: 'color',
-            label: { en: 'Text Color', ko: '텍스트 색상' },
-          },
-          {
-            key: 'spinner.text',
-            type: 'text',
-            label: { en: 'Text', ko: '텍스트' },
-            helperText: {
-              en: 'Optional center text inside the spinner. Supports numbers or short phrases.',
-              ko: '스피너 중앙에 표시할 선택적 텍스트입니다. 숫자나 짧은 문구를 사용할 수 있습니다.',
-            },
-          },
-        ],
-      },
-      {
-        id: 'overlay',
-        label: { en: 'Overlay', ko: '오버레이' },
-        controls: [
-          {
-            key: 'overlay.blurStrength',
-            type: 'slider',
-            label: { en: 'Blur Strength', ko: '블러 강도' },
-            min: 0,
-            max: 30,
-            step: 1,
-          },
-          {
-            key: 'overlay.backgroundColor',
-            type: 'color',
-            label: { en: 'Background Color', ko: '배경 색상' },
-          },
-        ],
-      },
-      {
-        key: 'description',
-        type: 'text',
-        label: { en: 'Description', ko: '설명' },
-        helperText: {
-          en: 'Text shown under the spinner. Leave empty to hide.',
-          ko: '스피너 아래에 표시되는 문구입니다. 비워두면 숨겨집니다.',
-        },
-      },
-    ],
   },
 ]
 
 export const componentMap = new Map(componentCatalog.map((item) => [item.id, item]))
 
-export const getComponentDefinition = (id: string) => componentMap.get(id)
+export const getComponentSummary = (id: string) => componentMap.get(id)

--- a/playground/src/library/types.ts
+++ b/playground/src/library/types.ts
@@ -1,0 +1,26 @@
+export type LocaleCopy = {
+  en: string
+  ko: string
+}
+
+export type PlaygroundPropValue = string | number | boolean | null | undefined
+
+export type ControlType = 'boolean' | 'slider' | 'color' | 'text' | 'textarea'
+
+export interface ControlDefinition {
+  key: string
+  type: ControlType
+  label: LocaleCopy
+  helperText?: LocaleCopy
+  min?: number
+  max?: number
+  step?: number
+}
+
+export interface GroupDefinition {
+  id: string
+  label: LocaleCopy
+  controls: ControlDefinition[]
+}
+
+export type PropertyDefinition = ControlDefinition | GroupDefinition

--- a/playground/src/views/core/controls/field.vue
+++ b/playground/src/views/core/controls/field.vue
@@ -6,7 +6,7 @@ import InputText from 'primevue/inputtext'
 import Slider from 'primevue/slider'
 import Textarea from 'primevue/textarea'
 import { ElColorPicker } from 'element-plus'
-import type { ControlDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/catalog'
+import type { ControlDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 import { toRgba } from '@shared/color'
 

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -1,43 +1,83 @@
 <script setup lang="ts">
-import { onBeforeMount, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { ControlDefinition, GroupDefinition, LabComponentDefinition, PlaygroundPropValue } from '@/library/catalog'
+import type { ComponentDemo } from '@/demos/types'
+import type { ControlDefinition, GroupDefinition, PlaygroundPropValue } from '@/library/types'
 import Field from './field.vue'
 import Section from './section.vue'
 
 const props = defineProps<{
-  definition: LabComponentDefinition
+  demo: ComponentDemo
 }>()
 
 const { t } = useI18n()
 
 const componentDefaults = ref<Record<string, PlaygroundPropValue>>({})
 const demoProps = defineModel<Record<string, PlaygroundPropValue>>('props', { default: () => ({}) })
+
 type ControlSection = { id: string; group?: GroupDefinition; controls: ControlDefinition[] }
 
-const controlSections = props.definition.properties.map<ControlSection>((property) => {
-  if ('controls' in property) {
-    return {
-      id: property.id,
-      group: property,
-      controls: property.controls,
+const controlSections = computed<ControlSection[]>(() =>
+  props.demo.properties.map((property) => {
+    if ('controls' in property) {
+      return {
+        id: property.id,
+        group: property,
+        controls: property.controls,
+      }
     }
-  }
 
-  return {
-    id: property.key,
-    group: undefined,
-    controls: [property],
-  }
-})
+    return {
+      id: property.key,
+      group: undefined,
+      controls: [property],
+    }
+  })
+)
 
 const hasOwn = (object: Record<string, unknown>, key: string) => Object.prototype.hasOwnProperty.call(object, key)
 
-const isControlOptional = (control: ControlDefinition) => !hasOwn(componentDefaults.value, control.key)
+const flattenDefaults = (defaults: Record<string, unknown> | undefined) => {
+  const flattened: Record<string, PlaygroundPropValue> = {}
+
+  if (!defaults) {
+    return flattened
+  }
+
+  const visit = (value: unknown, path: string[]) => {
+    if (typeof value === 'function') {
+      visit((value as () => unknown)(), path)
+      return
+    }
+
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.entries(value as Record<string, unknown>).forEach(([key, nested]) => {
+        visit(nested, [...path, key])
+      })
+      return
+    }
+
+    if (value === undefined) {
+      return
+    }
+
+    if (path.length > 0) {
+      flattened[path.join('.')] = value as PlaygroundPropValue
+    }
+  }
+
+  Object.entries(defaults).forEach(([key, value]) => {
+    visit(value, [key])
+  })
+
+  return flattened
+}
 
 const applyDefaults = () => {
   demoProps.value = { ...componentDefaults.value }
 }
+
+const isControlOptional = (control: ControlDefinition) => !hasOwn(componentDefaults.value, control.key)
 
 const handleOptionalToggle = (control: ControlDefinition, isActive: boolean | undefined) => {
   const checked = Boolean(isActive)
@@ -69,57 +109,19 @@ const handleOptionalToggle = (control: ControlDefinition, isActive: boolean | un
     }
 
     demoProps.value[control.key] = value
-  } else {
-    if (hasOwn(demoProps.value, control.key)) {
-      delete demoProps.value[control.key]
-    }
+  } else if (hasOwn(demoProps.value, control.key)) {
+    delete demoProps.value[control.key]
   }
 }
 
-const loadComponentDefaults = async () => {
-  componentDefaults.value = {}
-  demoProps.value = {}
-
-  const module = await props.definition.component()
-  const flattened: Record<string, PlaygroundPropValue> = {}
-
-  const visit = (value: unknown, path: string[]) => {
-    if (typeof value === 'function') {
-      visit((value as () => unknown)(), path)
-      return
-    }
-
-    if (value && typeof value === 'object' && !Array.isArray(value)) {
-      Object.entries(value as Record<string, unknown>).forEach(([key, nested]) => {
-        visit(nested, [...path, key])
-      })
-      return
-    }
-
-    if (value === undefined) {
-      return
-    }
-
-    if (path.length > 0) {
-      flattened[path.join('.')] = value as PlaygroundPropValue
-    }
-  }
-
-  const defaultsSource = (module as { defaultProps?: unknown }).defaultProps
-  if (defaultsSource && typeof defaultsSource === 'object' && !Array.isArray(defaultsSource)) {
-    Object.entries(defaultsSource as Record<string, unknown>).forEach(([key, value]) => {
-      visit(value, [key])
-    })
-  }
-
-  componentDefaults.value = flattened
-  applyDefaults()
-}
-
-onBeforeMount(() => {
-  void loadComponentDefaults()
-})
-
+watch(
+  () => props.demo.defaultProps,
+  (defaults) => {
+    componentDefaults.value = flattenDefaults(defaults)
+    applyDefaults()
+  },
+  { immediate: true, deep: true }
+)
 </script>
 
 <template>

--- a/playground/src/views/core/controls/section.vue
+++ b/playground/src/views/core/controls/section.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import type { ControlDefinition, GroupDefinition, LocaleCopy } from '@/library/catalog'
+import type { ControlDefinition, GroupDefinition, LocaleCopy } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 
 const props = defineProps<{

--- a/playground/src/views/core/index.vue
+++ b/playground/src/views/core/index.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import type { LabComponentDefinition, PlaygroundPropValue } from '@/library/catalog'
-import { getComponentDefinition } from '@/library/catalog'
+import { computed, ref, watch } from 'vue'
+import type { ComponentDemo } from '@/demos/types'
+import { getComponentDemo } from '@/demos'
+import type { LabComponentSummary } from '@/library/catalog'
+import { getComponentSummary } from '@/library/catalog'
+import type { PlaygroundPropValue } from '@/library/types'
 import Controls from './controls/index.vue'
 import NotFound from './notFound.vue'
 import Preview from './preview.vue'
@@ -10,21 +13,30 @@ const props = defineProps<{
   componentId: string
 }>()
 
-const definition = computed<LabComponentDefinition | undefined>(() => getComponentDefinition(props.componentId))
+const summary = computed<LabComponentSummary | undefined>(() => getComponentSummary(props.componentId))
+const demo = computed<ComponentDemo | undefined>(() => getComponentDemo(props.componentId))
 
 const demoProps = ref<Record<string, PlaygroundPropValue>>({})
+
+watch(
+  () => props.componentId,
+  () => {
+    demoProps.value = {}
+  }
+)
 </script>
 
 <template>
-  <div v-if="definition" class="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_22rem]">
+  <div v-if="summary && demo" class="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_22rem]">
     <Preview
-      :key="definition.id"
-      :definition="definition"
+      :key="summary.id"
+      :summary="summary"
+      :demo="demo"
       :demo-props="demoProps"
     />
     <Controls
-      :key="definition.id"
-      :definition="definition"
+      :key="summary.id"
+      :demo="demo"
       v-model:props="demoProps"
     />
   </div>

--- a/playground/src/views/core/preview.vue
+++ b/playground/src/views/core/preview.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, watch } from 'vue'
-import type { AsyncComponentLoader } from 'vue'
+import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import Spinner from '@library/components/Spinner.vue'
-import type { LabComponentDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/catalog'
+import type { ComponentDemo } from '@/demos/types'
+import type { LabComponentSummary } from '@/library/catalog'
+import type { LocaleCopy, PlaygroundPropValue } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 
 const props = defineProps<{
-  definition: LabComponentDefinition
+  summary: LabComponentSummary
+  demo: ComponentDemo
   demoProps: Record<string, PlaygroundPropValue>
 }>()
 
@@ -15,10 +16,9 @@ const { t, locale } = useI18n()
 
 const localize = (copy: LocaleCopy) => copy[(locale.value as SupportedLocale)] ?? copy.en
 
-const localizedName = computed(() => localize(props.definition.name))
-const localizedDescription = computed(() => localize(props.definition.description))
-
-const demoComponent = defineAsyncComponent((props.definition.preview ?? props.definition.component) as AsyncComponentLoader<any>)
+const localizedName = computed(() => localize(props.summary.name))
+const localizedDescription = computed(() => localize(props.summary.description))
+const demoComponent = computed(() => props.demo.component)
 
 const resolvedDemoProps = computed(() => {
   const expanded: Record<string, unknown> = {}
@@ -72,17 +72,7 @@ watch(
       <p class="text-sm text-surface-600 dark:text-surface-300">{{ localizedDescription }}</p>
     </header>
     <div class="relative min-h-[360px] overflow-hidden rounded-3xl border border-surface-200/70 bg-surface-0 p-6 shadow-inner dark:border-surface-800/70 dark:bg-surface-900">
-      <Suspense v-if="demoComponent">
-        <component :is="demoComponent" v-bind="resolvedDemoProps" />
-        <template #fallback>
-          <div class="flex h-full items-center justify-center text-surface-400">
-            <Spinner :diameter="72" :thickness="6" />
-          </div>
-        </template>
-      </Suspense>
-      <div v-else class="flex h-full items-center justify-center text-surface-400">
-        <Spinner :diameter="72" :thickness="6" />
-      </div>
+      <component :is="demoComponent" v-bind="resolvedDemoProps" />
     </div>
   </section>
 </template>


### PR DESCRIPTION
## Summary
- reduce the component catalog to only expose id, name, and description
- move property metadata and default props into each demo and add a central demo registry
- update core playground views to load demo components directly and reuse the new metadata helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3c5664f6c832c88c59e6e4d4fd3e4