### PR TITLE
Center QR code slot and rename data prop

### DIFF
--- a/library/components/QrCode.vue
+++ b/library/components/QrCode.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
 export const defaultProps = {
-  content: window.location.href,
+  data: window.location.href,
   lightColor: 'white',
   darkColor: 'black',
 } as const
 
 export type props = {
-  content: string
+  data: string
   lightColor?: string
   darkColor?: string
 }
@@ -30,7 +30,7 @@ const updateQrCode = () => {
   const lightHex = toHex(props.lightColor) || '#ffffff'
 
   QRCode.toDataURL(
-    props.content,
+    props.data,
     {
       margin: 0,
       color: {
@@ -51,7 +51,7 @@ const updateQrCode = () => {
 }
 
 watch(
-  () => [props.content, props.darkColor, props.lightColor],
+  () => [props.data, props.darkColor, props.lightColor],
   updateQrCode
 )
 
@@ -64,7 +64,10 @@ updateQrCode()
     <div v-else class="flex h-full w-full items-center justify-center text-xs text-center">
       <span>{{ qrError }}</span>
     </div>
-    <div class="absolute flex h-1/4 w-1/4 items-center justify-center" aria-hidden="true">
+    <div
+      class="absolute left-1/2 top-1/2 flex h-1/4 w-1/4 -translate-x-1/2 -translate-y-1/2 items-center justify-center"
+      aria-hidden="true"
+    >
       <slot />
     </div>
   </section>

--- a/playground/src/demos/QrCodeDemo.vue
+++ b/playground/src/demos/QrCodeDemo.vue
@@ -16,9 +16,9 @@ export const demoConfig: ComponentDemoConfig = {
       label: { en: 'Dark Color', ko: '어두운 색상' },
     },
     {
-      key: 'content',
+      key: 'data',
       type: 'textarea',
-      label: { en: 'Content', ko: '콘텐츠' },
+      label: { en: 'Data', ko: '데이터' },
       helperText: {
         en: 'Text or URL that will be encoded inside the QR code.',
         ko: 'QR 코드에 담을 텍스트 또는 URL을 입력하세요.',
@@ -40,11 +40,24 @@ export const demoConfig: ComponentDemoConfig = {
 <script setup lang="ts">
 import { QrCode, type QrCodeProps } from '@library/components'
 
-defineProps<QrCodeProps>()
+const props = defineProps<QrCodeProps & { icon?: string }>()
 </script>
 
 <template>
   <div class="flex justify-center">
-    <QrCode v-bind="$props" class="w-64 h-64">test</QrCode>
+    <QrCode
+      :data="props.data"
+      :light-color="props.lightColor"
+      :dark-color="props.darkColor"
+      class="h-64 w-64"
+    >
+      <img
+        v-if="props.icon"
+        :src="props.icon"
+        alt="QR code center icon"
+        class="h-full w-full rounded-xl object-cover"
+      />
+      <span v-else class="text-base font-medium text-surface-900">QR</span>
+    </QrCode>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- rename the QR code component property from `content` to `data` and update its usage in the demo configuration
- center the QR code slot overlay so custom icons render in the middle of the code
- enhance the demo to preview an optional center icon while passing the updated props

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3d66ada7c832caa4a64fa14fd1969