### PR TITLE
feat: center qr code slot and rename data prop

### DIFF
--- a/library/components/QrCode.vue
+++ b/library/components/QrCode.vue
@@ -64,10 +64,7 @@ updateQrCode()
     <div v-else class="flex h-full w-full items-center justify-center text-xs text-center">
       <span>{{ qrError }}</span>
     </div>
-    <div
-      class="absolute left-1/2 top-1/2 flex h-1/4 w-1/4 -translate-x-1/2 -translate-y-1/2 items-center justify-center"
-      aria-hidden="true"
-    >
+    <div class="absolute left-1/2 top-1/2 h-1/4 w-1/4 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center" aria-hidden="true">
       <slot />
     </div>
   </section>

--- a/library/components/QrCode.vue
+++ b/library/components/QrCode.vue
@@ -1,12 +1,12 @@
 <script lang="ts">
 export const defaultProps = {
-  content: window.location.href,
+  data: window.location.href,
   lightColor: 'white',
   darkColor: 'black',
 } as const
 
 export type props = {
-  content: string
+  data: string
   lightColor?: string
   darkColor?: string
 }
@@ -30,7 +30,7 @@ const updateQrCode = () => {
   const lightHex = toHex(props.lightColor) || '#ffffff'
 
   QRCode.toDataURL(
-    props.content,
+    props.data,
     {
       margin: 0,
       color: {
@@ -51,7 +51,7 @@ const updateQrCode = () => {
 }
 
 watch(
-  () => [props.content, props.darkColor, props.lightColor],
+  () => [props.data, props.darkColor, props.lightColor],
   updateQrCode
 )
 
@@ -64,7 +64,10 @@ updateQrCode()
     <div v-else class="flex h-full w-full items-center justify-center text-xs text-center">
       <span>{{ qrError }}</span>
     </div>
-    <div class="absolute flex h-1/4 w-1/4 items-center justify-center" aria-hidden="true">
+    <div
+      class="absolute left-1/2 top-1/2 flex h-1/4 w-1/4 -translate-x-1/2 -translate-y-1/2 items-center justify-center"
+      aria-hidden="true"
+    >
       <slot />
     </div>
   </section>

--- a/playground/src/demos/QrCodeDemo.vue
+++ b/playground/src/demos/QrCodeDemo.vue
@@ -24,15 +24,6 @@ export const demoConfig: ComponentDemoConfig = {
         ko: 'QR 코드에 담을 텍스트 또는 URL을 입력하세요.',
       },
     },
-    {
-      key: 'icon',
-      type: 'text',
-      label: { en: 'Icon URL', ko: '아이콘 주소' },
-      helperText: {
-        en: 'Center image URL. Leave empty to hide the icon.',
-        ko: '중앙에 표시할 이미지 주소입니다. 비워두면 아이콘이 숨겨집니다.',
-      },
-    },
   ],
 }
 </script>

--- a/playground/src/demos/QrCodeDemo.vue
+++ b/playground/src/demos/QrCodeDemo.vue
@@ -16,9 +16,9 @@ export const demoConfig: ComponentDemoConfig = {
       label: { en: 'Dark Color', ko: '어두운 색상' },
     },
     {
-      key: 'content',
+      key: 'data',
       type: 'textarea',
-      label: { en: 'Content', ko: '콘텐츠' },
+      label: { en: 'Data', ko: '데이터' },
       helperText: {
         en: 'Text or URL that will be encoded inside the QR code.',
         ko: 'QR 코드에 담을 텍스트 또는 URL을 입력하세요.',


### PR DESCRIPTION
## Summary
- rename the QR code component's `content` prop to `data` and update its defaults
- center the optional slot overlay directly over the QR code graphic
- update the playground demo configuration to surface the renamed prop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3d66ada7c832caa4a64fa14fd1969