### PR TITLE
Add ActionableCard component with playground demo

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -1,0 +1,120 @@
+<script lang="ts">
+export const defaultProps = {
+  orientation: 'auto',
+  minHorizontalWidth: 480,
+} as const satisfies Record<string, unknown>
+
+export type Orientation = 'vertical' | 'horizontal' | 'auto'
+
+export type props = {
+  orientation?: Orientation
+  minHorizontalWidth?: number
+}
+</script>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const props = withDefaults(defineProps<props>(), defaultProps)
+
+const containerRef = ref<HTMLElement | null>(null)
+const layout = ref<'vertical' | 'horizontal'>(props.orientation === 'vertical' ? 'vertical' : 'horizontal')
+let resizeObserver: ResizeObserver | undefined
+
+const isAuto = computed(() => props.orientation === 'auto')
+const horizontalBreakpoint = computed(() => Math.max(0, props.minHorizontalWidth))
+
+const applyLayout = (width?: number) => {
+  if (props.orientation === 'vertical' || props.orientation === 'horizontal') {
+    layout.value = props.orientation
+    return
+  }
+
+  const effectiveWidth =
+    width ?? containerRef.value?.offsetWidth ?? horizontalBreakpoint.value
+
+  layout.value = effectiveWidth < horizontalBreakpoint.value ? 'vertical' : 'horizontal'
+}
+
+const ensureResizeObserver = () => {
+  if (!isAuto.value || typeof ResizeObserver === 'undefined' || !containerRef.value) {
+    return
+  }
+
+  if (!resizeObserver) {
+    resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target === containerRef.value) {
+          applyLayout(entry.contentRect.width)
+        }
+      }
+    })
+  } else {
+    resizeObserver.disconnect()
+  }
+
+  resizeObserver.observe(containerRef.value)
+}
+
+onMounted(() => {
+  applyLayout()
+  ensureResizeObserver()
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+})
+
+watch(
+  () => [props.orientation, props.minHorizontalWidth],
+  () => {
+    applyLayout()
+
+    if (!isAuto.value) {
+      resizeObserver?.disconnect()
+      resizeObserver = undefined
+      return
+    }
+
+    ensureResizeObserver()
+  },
+  { flush: 'post' }
+)
+
+const containerClasses = computed(() => [
+  'actionable-card relative inline-flex w-full overflow-hidden rounded-3xl border border-surface-200/70 bg-surface-0 text-left shadow-sm transition-colors dark:border-surface-800/60 dark:bg-surface-900',
+  layout.value === 'horizontal' ? 'flex-row' : 'flex-col',
+])
+
+const bodyClasses = computed(() => [
+  'actionable-card__body flex min-w-0 flex-1 flex-col gap-4 p-6 text-surface-900 dark:text-surface-0',
+])
+
+const actionClasses = computed(() => [
+  'actionable-card__action flex items-center justify-center bg-surface-900 px-6 py-5 text-sm font-semibold text-surface-0 transition-colors dark:bg-surface-800',
+  layout.value === 'horizontal' ? 'min-w-[112px]' : 'w-full',
+])
+</script>
+
+<template>
+  <section ref="containerRef" :class="containerClasses">
+    <div :class="bodyClasses">
+      <slot :orientation="layout" />
+    </div>
+    <div :class="actionClasses">
+      <slot name="action" :orientation="layout" />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.actionable-card {
+  --actionable-card-radius: 1.75rem;
+  border-radius: var(--actionable-card-radius);
+}
+
+.actionable-card__body,
+.actionable-card__action {
+  border-radius: 0;
+}
+</style>

--- a/library/components/index.ts
+++ b/library/components/index.ts
@@ -1,3 +1,4 @@
+export { default as ActionableCard, type props as ActionableCardProps } from './ActionableCard.vue'
 export { default as BlurOverlay, type props as BlurOverlayProps  } from './BlurOverlay.vue'
 export { default as LoadingOverlay, type props as LoadingOverlayProps } from './LoadingOverlay.vue'
 export { default as QrCode, type props as QrCodeProps } from './QrCode.vue'

--- a/playground/src/demos/ActionableCardDemo.vue
+++ b/playground/src/demos/ActionableCardDemo.vue
@@ -1,0 +1,88 @@
+<script lang="ts">
+import { defaultProps as actionableCardDefaults } from '@library/components/ActionableCard.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: actionableCardDefaults,
+  properties: [
+    {
+      id: 'layout',
+      label: { en: 'Layout', ko: '레이아웃' },
+      controls: [
+        {
+          key: 'orientation',
+          type: 'text',
+          label: { en: 'Orientation', ko: '방향' },
+          helperText: {
+            en: "Use 'vertical', 'horizontal', or 'auto'.",
+            ko: "vertical, horizontal, auto 중 하나를 입력하세요.",
+          },
+        },
+        {
+          key: 'minHorizontalWidth',
+          type: 'slider',
+          label: { en: 'Auto Switch Width', ko: '자동 전환 너비' },
+          min: 320,
+          max: 960,
+          step: 20,
+        },
+      ],
+    },
+  ],
+}
+</script>
+
+<script setup lang="ts">
+import { ActionableCard, type ActionableCardProps } from '@library/components'
+
+defineProps<ActionableCardProps>()
+</script>
+
+<template>
+  <div class="mx-auto flex max-w-3xl flex-col gap-6">
+    <ActionableCard v-bind="$props">
+      <div class="flex flex-col gap-6">
+        <header class="flex items-center gap-4">
+          <div class="grid h-16 w-16 place-items-center rounded-full bg-[#fff5d6] text-3xl font-semibold text-[#f5a300]">
+            KB
+          </div>
+          <div class="flex flex-col gap-2">
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-surface-500 dark:text-surface-300">
+              <span class="text-lg font-semibold text-surface-900 dark:text-surface-0">KB국민</span>
+              <span class="text-sm font-medium">강인준</span>
+            </div>
+            <div class="flex flex-wrap items-center gap-2 text-sm font-medium text-primary-500">
+              <span class="text-lg tracking-[0.08em]">93800200352361</span>
+              <button
+                type="button"
+                class="inline-flex items-center gap-2 rounded-full border border-primary-100 px-3 py-1 text-xs font-semibold text-primary-500 transition hover:border-primary-200 hover:text-primary-400 dark:border-primary-400/30 dark:text-primary-300"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" class="h-4 w-4">
+                  <rect x="9" y="9" width="11" height="13" rx="2" ry="2" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+                복사
+              </button>
+            </div>
+          </div>
+        </header>
+        <p class="text-sm leading-relaxed text-surface-500 dark:text-surface-300">
+          간편 송금 계좌 정보입니다. 자동 전환 모드를 사용하면 가로 폭에 따라 카드 레이아웃이 자연스럽게 바뀝니다.
+        </p>
+      </div>
+      <template #action>
+        <button
+          type="button"
+          class="flex w-full items-center justify-center gap-2 rounded-none text-base font-semibold tracking-tight text-surface-0"
+        >
+          이체 정보 복사
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="h-5 w-5">
+            <path d="M8 17h8" stroke-linecap="round" />
+            <path d="M12 3v14" stroke-linecap="round" />
+            <rect x="4" y="3" width="16" height="18" rx="4" ry="4" />
+          </svg>
+        </button>
+      </template>
+    </ActionableCard>
+  </div>
+</template>

--- a/playground/src/demos/index.ts
+++ b/playground/src/demos/index.ts
@@ -1,3 +1,4 @@
+import ActionableCardDemo, { demoConfig as actionableCardConfig } from './ActionableCardDemo.vue'
 import BlurOverlayDemo, { demoConfig as blurOverlayConfig } from './BlurOverlayDemo.vue'
 import LoadingOverlayDemo, { demoConfig as loadingOverlayConfig } from './LoadingOverlayDemo.vue'
 import QrCodeDemo, { demoConfig as qrCodeConfig } from './QrCodeDemo.vue'
@@ -5,6 +6,10 @@ import SpinnerDemo, { demoConfig as spinnerConfig } from './SpinnerDemo.vue'
 import type { ComponentDemo } from './types'
 
 const demoEntries: Record<string, ComponentDemo> = {
+  'actionable-card': {
+    component: ActionableCardDemo,
+    ...actionableCardConfig,
+  },
   'blur-overlay': {
     component: BlurOverlayDemo,
     ...blurOverlayConfig,

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -8,6 +8,17 @@ export interface LabComponentSummary {
 
 export const componentCatalog: LabComponentSummary[] = [
   {
+    id: 'actionable-card',
+    name: {
+      en: 'Actionable Card',
+      ko: '액션 카드',
+    },
+    description: {
+      en: 'Card and action area seamlessly combined with responsive layouts.',
+      ko: '카드와 액션 영역이 끊김 없이 이어지고 화면 너비에 맞춰 레이아웃이 바뀝니다.',
+    },
+  },
+  {
     id: 'qr-code',
     name: {
       en: 'QR Code',


### PR DESCRIPTION
## Summary
- add an ActionableCard component that merges card and action surfaces with vertical, horizontal, and auto layouts
- wire the component into the component library exports and playground catalog
- provide a playground demo showcasing the seamless account card design and responsive switching

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3eabb68a4832cbb0471869ea75569