### PR TITLE
feat: add ActionableCard component

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -1,0 +1,122 @@
+<script lang="ts">
+export const defaultProps = {
+  orientation: 'auto',
+  breakpoint: 640,
+} as const satisfies {
+  orientation: Orientation
+  breakpoint: number
+}
+
+export type Orientation = 'vertical' | 'horizontal' | 'auto'
+
+export type props = {
+  orientation?: Orientation
+  /**
+   * Width (in pixels) used when orientation is set to `auto`.
+   * When the card becomes narrower than this value it will switch to the vertical layout.
+   */
+  breakpoint?: number
+}
+</script>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+const props = withDefaults(defineProps<props>(), defaultProps)
+
+const rootRef = ref<HTMLElement | null>(null)
+const containerWidth = ref<number>(0)
+let resizeObserver: ResizeObserver | null = null
+
+const effectiveOrientation = computed(() => {
+  if (props.orientation === 'auto') {
+    if (containerWidth.value > 0 && containerWidth.value < props.breakpoint) {
+      return 'vertical' as const
+    }
+    return 'horizontal' as const
+  }
+
+  return props.orientation
+})
+
+const containerClasses = computed(() => [
+  'actionable-card',
+  'flex overflow-hidden rounded-3xl border border-surface-200/70 bg-white text-surface-900 shadow-soft transition-colors duration-200 dark:border-surface-700/60 dark:bg-surface-900/80 dark:text-surface-100',
+  effectiveOrientation.value === 'vertical' ? 'flex-col' : 'flex-row',
+])
+
+const cardSectionClasses = computed(() => [
+  'actionable-card__content flex flex-1 flex-col justify-center gap-4 p-6',
+  effectiveOrientation.value === 'horizontal' ? 'min-h-[144px]' : 'min-h-[120px]'
+])
+
+const actionSectionClasses = computed(() => [
+  'actionable-card__action flex items-center justify-center bg-surface-900 text-white transition-colors duration-200 dark:bg-surface-50 dark:text-surface-900',
+  effectiveOrientation.value === 'horizontal'
+    ? 'min-h-[120px] min-w-[160px] px-6'
+    : 'w-full px-6 py-4'
+])
+
+onMounted(() => {
+  if (!rootRef.value) {
+    return
+  }
+
+  const updateWidth = (width: number) => {
+    containerWidth.value = Math.max(0, Math.round(width))
+  }
+
+  if (typeof window !== 'undefined' && 'ResizeObserver' in window) {
+    resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) {
+        updateWidth(entry.contentRect.width)
+      }
+    })
+
+    resizeObserver.observe(rootRef.value)
+    updateWidth(rootRef.value.getBoundingClientRect().width)
+  } else {
+    updateWidth(rootRef.value.getBoundingClientRect().width)
+  }
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+})
+</script>
+
+<template>
+  <section ref="rootRef" :class="containerClasses">
+    <div :class="cardSectionClasses">
+      <slot />
+    </div>
+    <div :class="actionSectionClasses">
+      <slot name="action" />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.actionable-card {
+  --actionable-card-bg: theme('colors.white');
+  --actionable-card-action-bg: theme('colors.slate.900');
+  --actionable-card-action-text: theme('colors.white');
+}
+
+:global(.dark) .actionable-card {
+  --actionable-card-bg: rgba(15, 23, 42, 0.75);
+  --actionable-card-action-bg: theme('colors.slate.100');
+  --actionable-card-action-text: theme('colors.slate.900');
+}
+
+.actionable-card__content {
+  background: var(--actionable-card-bg);
+}
+
+.actionable-card__action {
+  background: var(--actionable-card-action-bg);
+  color: var(--actionable-card-action-text);
+}
+</style>

--- a/library/components/index.ts
+++ b/library/components/index.ts
@@ -1,4 +1,5 @@
-export { default as BlurOverlay, type props as BlurOverlayProps  } from './BlurOverlay.vue'
+export { default as ActionableCard, type props as ActionableCardProps } from './ActionableCard.vue'
+export { default as BlurOverlay, type props as BlurOverlayProps } from './BlurOverlay.vue'
 export { default as LoadingOverlay, type props as LoadingOverlayProps } from './LoadingOverlay.vue'
 export { default as QrCode, type props as QrCodeProps } from './QrCode.vue'
 export { default as Spinner, type props as SpinnerProps } from './Spinner.vue'

--- a/playground/src/demos/ActionableCardDemo.vue
+++ b/playground/src/demos/ActionableCardDemo.vue
@@ -1,0 +1,90 @@
+<script lang="ts">
+import { defaultProps as actionableCardDefaults } from '@library/components/ActionableCard.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: actionableCardDefaults,
+  properties: [
+    {
+      key: 'orientation',
+      type: 'select',
+      label: { en: 'Orientation', ko: '배치 방향' },
+      options: [
+        { value: 'auto', label: { en: 'Auto', ko: '자동' } },
+        { value: 'horizontal', label: { en: 'Horizontal', ko: '가로' } },
+        { value: 'vertical', label: { en: 'Vertical', ko: '세로' } },
+      ],
+      helperText: {
+        en: 'Switch between horizontal, vertical, or automatic layout.',
+        ko: '가로/세로 또는 자동 레이아웃을 선택하세요.',
+      },
+    },
+    {
+      key: 'breakpoint',
+      type: 'slider',
+      label: { en: 'Auto Breakpoint', ko: '자동 전환 너비' },
+      min: 320,
+      max: 960,
+      step: 10,
+      helperText: {
+        en: 'When orientation is auto, the layout becomes vertical below this width (px).',
+        ko: '방향이 자동일 때 이 너비(px) 이하에서 세로 레이아웃으로 전환됩니다.',
+      },
+    },
+  ],
+}
+</script>
+
+<script setup lang="ts">
+import { ActionableCard, type ActionableCardProps } from '@library/components'
+
+defineProps<ActionableCardProps>()
+</script>
+
+<template>
+  <ActionableCard v-bind="$props">
+    <div class="flex items-start gap-4">
+      <div class="flex h-14 w-14 items-center justify-center rounded-full bg-amber-100 text-xl font-semibold text-amber-500">
+        KB
+      </div>
+      <div class="flex flex-col gap-2">
+        <div class="flex flex-wrap items-baseline gap-x-2">
+          <span class="text-lg font-semibold text-surface-900 dark:text-surface-50">KB국민</span>
+          <span class="text-sm font-medium text-surface-500 dark:text-surface-400">강인준</span>
+        </div>
+        <div class="flex items-center gap-2 text-base font-medium text-primary-600 dark:text-primary-300">
+          <span class="tracking-wide">9380020052361</span>
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-[0.2em] text-primary-500 transition hover:text-primary-400"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="h-4 w-4">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            Copy
+          </button>
+        </div>
+        <p class="text-sm text-surface-500 dark:text-surface-400">
+          이 계좌로 입금되는 금액을 확인하고 바로 공유하세요.
+        </p>
+      </div>
+    </div>
+    <template #action>
+      <button
+        type="button"
+        class="group inline-flex items-center gap-3 rounded-full bg-transparent px-4 py-2 text-base font-semibold text-white transition-colors hover:text-primary-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" class="h-6 w-6">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M8 3h8a2 2 0 0 1 2 2v2H6V5a2 2 0 0 1 2-2Zm10 6H6v10a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V9Zm-6 4v4"
+          />
+          <path stroke-linecap="round" d="M9.5 13.5h5" />
+        </svg>
+        이체 정보 복사
+      </button>
+    </template>
+  </ActionableCard>
+</template>

--- a/playground/src/demos/index.ts
+++ b/playground/src/demos/index.ts
@@ -1,3 +1,4 @@
+import ActionableCardDemo, { demoConfig as actionableCardConfig } from './ActionableCardDemo.vue'
 import BlurOverlayDemo, { demoConfig as blurOverlayConfig } from './BlurOverlayDemo.vue'
 import LoadingOverlayDemo, { demoConfig as loadingOverlayConfig } from './LoadingOverlayDemo.vue'
 import QrCodeDemo, { demoConfig as qrCodeConfig } from './QrCodeDemo.vue'
@@ -5,6 +6,10 @@ import SpinnerDemo, { demoConfig as spinnerConfig } from './SpinnerDemo.vue'
 import type { ComponentDemo } from './types'
 
 const demoEntries: Record<string, ComponentDemo> = {
+  'actionable-card': {
+    component: ActionableCardDemo,
+    ...actionableCardConfig,
+  },
   'blur-overlay': {
     component: BlurOverlayDemo,
     ...blurOverlayConfig,

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -8,6 +8,17 @@ export interface LabComponentSummary {
 
 export const componentCatalog: LabComponentSummary[] = [
   {
+    id: 'actionable-card',
+    name: {
+      en: 'Actionable Card',
+      ko: '액션 카드',
+    },
+    description: {
+      en: 'Combine content and a primary action into a seamless, responsive card layout.',
+      ko: '콘텐츠와 주요 버튼을 하나의 카드로 자연스럽게 연결하는 반응형 컴포넌트입니다.',
+    },
+  },
+  {
     id: 'qr-code',
     name: {
       en: 'QR Code',

--- a/playground/src/library/types.ts
+++ b/playground/src/library/types.ts
@@ -5,7 +5,12 @@ export type LocaleCopy = {
 
 export type PlaygroundPropValue = string | number | boolean | null | undefined
 
-export type ControlType = 'boolean' | 'slider' | 'color' | 'text' | 'textarea'
+export interface SelectOption {
+  label: LocaleCopy
+  value: PlaygroundPropValue
+}
+
+export type ControlType = 'boolean' | 'slider' | 'color' | 'text' | 'textarea' | 'select'
 
 export interface ControlDefinition {
   key: string
@@ -15,6 +20,7 @@ export interface ControlDefinition {
   min?: number
   max?: number
   step?: number
+  options?: SelectOption[]
 }
 
 export interface GroupDefinition {

--- a/playground/src/views/core/controls/field.vue
+++ b/playground/src/views/core/controls/field.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Checkbox from 'primevue/checkbox'
+import Dropdown from 'primevue/dropdown'
 import InputText from 'primevue/inputtext'
 import Slider from 'primevue/slider'
 import Textarea from 'primevue/textarea'
@@ -42,6 +43,13 @@ const stringModel = computed<string | undefined>({
   get: () => (typeof valueModel.value === 'string' ? valueModel.value : undefined),
   set: (value) => { valueModel.value = value },
 })
+
+const selectOptions = computed(() =>
+  props.control.options?.map((option) => ({
+    label: localize(option.label),
+    value: option.value,
+  })) ?? []
+)
 
 const colorModel = computed<string | null>({
   get: () => toRgba(stringModel.value),
@@ -87,6 +95,19 @@ const booleanModel = computed<boolean | undefined>({
         v-model="stringModel"
         :aria-labelledby="isOptional ? labelId : undefined"
         class="w-full"
+      />
+    </template>
+    <template v-else-if="control.type === 'select'">
+      <Dropdown
+        v-if="isActive"
+        :id="inputId"
+        v-model="valueModel"
+        :options="selectOptions"
+        option-label="label"
+        option-value="value"
+        class="w-full"
+        :aria-labelledby="isOptional ? labelId : undefined"
+        :show-clear="true"
       />
     </template>
     <template v-else-if="control.type === 'textarea'">

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -96,6 +96,9 @@ const handleOptionalToggle = (control: ControlDefinition, isActive: boolean | un
         case 'slider':
           value = control.min ?? 0
           break
+        case 'select':
+          value = control.options?.[0]?.value ?? ''
+          break
         case 'boolean':
           value = false
           break


### PR DESCRIPTION
## Summary
- add an ActionableCard component that keeps card content and actions seamless across vertical, horizontal, or auto layouts
- extend the playground to demo the new component and add select support for orientation controls
- document the component in the catalog so it shows up in the component lab

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3eabb68a4832cbb0471869ea75569