### PR TITLE
Add ActionableCard component with responsive playground demo

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -1,0 +1,58 @@
+<script lang="ts">
+export const defaultProps = {
+  actionLabel: '',
+  actionType: 'button',
+  disabled: false,
+} as const
+
+export type props = {
+  actionLabel?: string
+  actionType?: 'button' | 'submit' | 'reset'
+  disabled?: boolean
+}
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<props>(), defaultProps)
+
+const emit = defineEmits<{
+  (event: 'action', nativeEvent: MouseEvent): void
+}>()
+
+const buttonClasses = computed(() => [
+  'flex h-full min-h-[56px] w-full items-center justify-center gap-2 bg-slate-900 px-6 py-4 text-sm font-semibold text-white transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 sm:w-auto sm:min-h-0 sm:px-6 sm:py-0',
+  props.disabled
+    ? 'cursor-not-allowed opacity-60 hover:bg-slate-900 focus-visible:outline-none'
+    : 'hover:bg-slate-800',
+])
+
+const handleClick = (event: MouseEvent) => {
+  if (props.disabled) {
+    event.preventDefault()
+    return
+  }
+
+  emit('action', event)
+}
+</script>
+
+<template>
+  <section
+    class="flex w-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white text-slate-900 shadow-sm sm:flex-row dark:border-slate-800 dark:bg-slate-900 dark:text-white"
+  >
+    <div class="flex flex-1 flex-col gap-3 p-6 sm:p-8">
+      <slot />
+    </div>
+    <button
+      :class="buttonClasses"
+      :type="props.actionType"
+      :aria-label="props.actionLabel || undefined"
+      :disabled="props.disabled"
+      @click="handleClick"
+    >
+      <slot name="action" />
+    </button>
+  </section>
+</template>

--- a/library/components/index.ts
+++ b/library/components/index.ts
@@ -1,3 +1,4 @@
+export { default as ActionableCard, type props as ActionableCardProps } from './ActionableCard.vue'
 export { default as BlurOverlay, type props as BlurOverlayProps  } from './BlurOverlay.vue'
 export { default as LoadingOverlay, type props as LoadingOverlayProps } from './LoadingOverlay.vue'
 export { default as QrCode, type props as QrCodeProps } from './QrCode.vue'

--- a/playground/src/demos/ActionableCardDemo.vue
+++ b/playground/src/demos/ActionableCardDemo.vue
@@ -1,0 +1,141 @@
+<script lang="ts">
+import { defaultProps as actionableCardDefaults } from '@library/components/ActionableCard.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: actionableCardDefaults,
+  properties: [
+    {
+      key: 'actionLabel',
+      type: 'text',
+      label: { en: 'Action aria-label', ko: '액션 ARIA 레이블' },
+      helperText: {
+        en: 'Useful when the action content is icon-only on wide layouts.',
+        ko: '와이드 레이아웃에서 아이콘만 표시할 때 사용하면 좋아요.',
+      },
+    },
+    {
+      key: 'disabled',
+      type: 'boolean',
+      label: { en: 'Disabled', ko: '비활성화' },
+    },
+    {
+      key: 'actionType',
+      type: 'text',
+      label: { en: 'Button type', ko: '버튼 타입' },
+      helperText: {
+        en: 'button, submit, or reset',
+        ko: 'button, submit, reset 중 하나',
+      },
+    },
+  ],
+}
+</script>
+
+<script setup lang="ts">
+import { ActionableCard, type ActionableCardProps } from '@library/components'
+
+const account = {
+  bank: 'KB국민',
+  owner: '강일준',
+  number: '93800200532361',
+}
+
+const emitCopy = () => {
+  if (typeof navigator !== 'undefined' && navigator.clipboard) {
+    navigator.clipboard.writeText(account.number).catch(() => {})
+  }
+}
+
+defineProps<ActionableCardProps>()
+</script>
+
+<template>
+  <div class="max-w-xl">
+    <ActionableCard
+      v-bind="$props"
+      class="backdrop-blur-sm bg-white/95 shadow-lg ring-1 ring-slate-200/70"
+      @action="emitCopy"
+    >
+      <div class="flex items-center gap-4">
+        <span
+          class="flex h-12 w-12 items-center justify-center rounded-full bg-amber-100 text-xl font-semibold text-amber-500"
+        >
+          KB
+        </span>
+        <div class="flex flex-col gap-1 text-slate-700">
+          <p class="text-base font-semibold text-slate-900">
+            {{ account.bank }}
+            <span class="ml-2 text-sm font-medium text-slate-500">{{ account.owner }}</span>
+          </p>
+          <button
+            type="button"
+            class="group/number flex w-fit items-center gap-2 text-sm font-semibold text-slate-700 underline decoration-1 underline-offset-4"
+            @click="emitCopy"
+          >
+            <span class="tabular-nums tracking-wide">{{ account.number }}</span>
+            <svg
+              class="h-4 w-4 text-slate-500 transition group-hover/number:text-slate-700"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M9 9a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2z"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M5 15V6a2 2 0 0 1 2-2h7"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <template #action>
+        <span class="flex items-center gap-2 sm:hidden">
+          <span class="font-semibold text-white">이체 정보 복사</span>
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path
+              d="M9 9a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2z"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M5 15V6a2 2 0 0 1 2-2h7"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </span>
+        <svg class="hidden h-6 w-6 sm:block" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path
+            d="M9 9a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2z"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M5 15V6a2 2 0 0 1 2-2h7"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </template>
+    </ActionableCard>
+  </div>
+</template>

--- a/playground/src/demos/index.ts
+++ b/playground/src/demos/index.ts
@@ -1,3 +1,4 @@
+import ActionableCardDemo, { demoConfig as actionableCardConfig } from './ActionableCardDemo.vue'
 import BlurOverlayDemo, { demoConfig as blurOverlayConfig } from './BlurOverlayDemo.vue'
 import LoadingOverlayDemo, { demoConfig as loadingOverlayConfig } from './LoadingOverlayDemo.vue'
 import QrCodeDemo, { demoConfig as qrCodeConfig } from './QrCodeDemo.vue'
@@ -5,6 +6,10 @@ import SpinnerDemo, { demoConfig as spinnerConfig } from './SpinnerDemo.vue'
 import type { ComponentDemo } from './types'
 
 const demoEntries: Record<string, ComponentDemo> = {
+  'actionable-card': {
+    component: ActionableCardDemo,
+    ...actionableCardConfig,
+  },
   'blur-overlay': {
     component: BlurOverlayDemo,
     ...blurOverlayConfig,

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -8,6 +8,17 @@ export interface LabComponentSummary {
 
 export const componentCatalog: LabComponentSummary[] = [
   {
+    id: 'actionable-card',
+    name: {
+      en: 'Actionable Card',
+      ko: '액션 카드',
+    },
+    description: {
+      en: 'Combine rich content with a responsive action that adapts between stacked and compact layouts.',
+      ko: '리치 콘텐츠와 반응형 액션 버튼을 결합해 폭에 따라 세로와 컴팩트 레이아웃을 전환합니다.',
+    },
+  },
+  {
     id: 'qr-code',
     name: {
       en: 'QR Code',


### PR DESCRIPTION
## Summary
- add a responsive ActionableCard component that combines content with an integrated action slot
- export the new component from the library entry point for consumer access
- showcase the component in the playground with a demo, controls, and catalog metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f2ef2198832c98421e34b7f24071