### PR TITLE
Add ActionableCard component with demo

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -1,0 +1,47 @@
+<script lang="ts">
+export const defaultProps = {
+  cardClass: 'p-6 sm:p-8',
+  actionClass: 'bg-surface-950 text-surface-0',
+} as const
+
+export type props = {
+  cardClass?: string
+  actionClass?: string
+}
+</script>
+
+<script setup lang="ts">
+defineOptions({
+  name: 'ActionableCard',
+})
+
+defineSlots<{
+  default: () => unknown
+  action: () => unknown
+}>()
+
+const props = withDefaults(defineProps<props>(), defaultProps)
+</script>
+
+<template>
+  <section
+    class="actionable-card grid w-full grid-cols-1 overflow-hidden rounded-3xl border border-surface-200 bg-surface-0 text-surface-900 shadow-soft transition-colors sm:grid-cols-[minmax(0,1fr)_auto]"
+  >
+    <div class="card-area flex flex-col justify-center gap-4" :class="props.cardClass">
+      <slot />
+    </div>
+    <div
+      class="action-area flex min-h-[60px] items-stretch justify-center sm:min-h-full sm:min-w-[112px]"
+      :class="props.actionClass"
+    >
+      <slot name="action" />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.action-area ::v-slotted(*) {
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/library/components/index.ts
+++ b/library/components/index.ts
@@ -1,4 +1,5 @@
-export { default as BlurOverlay, type props as BlurOverlayProps  } from './BlurOverlay.vue'
+export { default as ActionableCard, type props as ActionableCardProps } from './ActionableCard.vue'
+export { default as BlurOverlay, type props as BlurOverlayProps } from './BlurOverlay.vue'
 export { default as LoadingOverlay, type props as LoadingOverlayProps } from './LoadingOverlay.vue'
 export { default as QrCode, type props as QrCodeProps } from './QrCode.vue'
 export { default as Spinner, type props as SpinnerProps } from './Spinner.vue'

--- a/playground/src/demos/ActionableCardDemo.vue
+++ b/playground/src/demos/ActionableCardDemo.vue
@@ -1,0 +1,70 @@
+<script lang="ts">
+import { defaultProps as actionableCardDefaults } from '@library/components/ActionableCard.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: actionableCardDefaults,
+  properties: [
+    {
+      key: 'cardClass',
+      type: 'text',
+      label: { en: 'Card classes', ko: '카드 클래스' },
+      helperText: {
+        en: 'Utility classes applied to the content area wrapper.',
+        ko: '콘텐츠 영역 래퍼에 적용할 Tailwind 클래스입니다.',
+      },
+    },
+    {
+      key: 'actionClass',
+      type: 'text',
+      label: { en: 'Action classes', ko: '액션 클래스' },
+      helperText: {
+        en: 'Utility classes applied to the action slot wrapper.',
+        ko: '액션 슬롯 래퍼에 적용할 Tailwind 클래스입니다.',
+      },
+    },
+  ],
+}
+</script>
+
+<script setup lang="ts">
+import { ActionableCard, type ActionableCardProps } from '@library/components'
+
+const props = defineProps<ActionableCardProps>()
+</script>
+
+<template>
+  <div class="flex justify-center">
+    <ActionableCard v-bind="props" class="max-w-2xl">
+      <div class="flex items-start gap-4">
+        <div class="flex h-14 w-14 items-center justify-center rounded-full bg-amber-100 text-2xl font-semibold text-amber-500">
+          KB
+        </div>
+        <div class="space-y-3">
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="text-lg font-semibold text-surface-900">KB국민</span>
+            <span class="text-sm font-medium text-surface-500">강일준</span>
+          </div>
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="text-lg font-semibold tracking-wide text-surface-900">93800200352361</span>
+            <i class="pi pi-clipboard text-base text-primary-500" aria-hidden="true"></i>
+          </div>
+        </div>
+      </div>
+      <template #action>
+        <button
+          type="button"
+          class="flex h-full min-h-[60px] w-full items-center justify-center gap-2 px-6 text-sm font-semibold text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 bg-primary-500 hover:bg-primary-400 focus-visible:outline-primary-200 sm:min-w-[112px]"
+          aria-label="이체 정보 복사"
+        >
+          <span class="flex items-center gap-2 sm:hidden">
+            <span class="font-semibold text-white">이체 정보 복사</span>
+            <i class="pi pi-clipboard text-base text-white" aria-hidden="true"></i>
+          </span>
+          <i class="pi pi-clipboard hidden text-xl text-white sm:flex" aria-hidden="true"></i>
+          <span class="sr-only sm:not-sr-only sm:hidden">이체 정보 복사</span>
+        </button>
+      </template>
+    </ActionableCard>
+  </div>
+</template>

--- a/playground/src/demos/index.ts
+++ b/playground/src/demos/index.ts
@@ -1,3 +1,4 @@
+import ActionableCardDemo, { demoConfig as actionableCardConfig } from './ActionableCardDemo.vue'
 import BlurOverlayDemo, { demoConfig as blurOverlayConfig } from './BlurOverlayDemo.vue'
 import LoadingOverlayDemo, { demoConfig as loadingOverlayConfig } from './LoadingOverlayDemo.vue'
 import QrCodeDemo, { demoConfig as qrCodeConfig } from './QrCodeDemo.vue'
@@ -5,6 +6,10 @@ import SpinnerDemo, { demoConfig as spinnerConfig } from './SpinnerDemo.vue'
 import type { ComponentDemo } from './types'
 
 const demoEntries: Record<string, ComponentDemo> = {
+  'actionable-card': {
+    component: ActionableCardDemo,
+    ...actionableCardConfig,
+  },
   'blur-overlay': {
     component: BlurOverlayDemo,
     ...blurOverlayConfig,

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -8,6 +8,17 @@ export interface LabComponentSummary {
 
 export const componentCatalog: LabComponentSummary[] = [
   {
+    id: 'actionable-card',
+    name: {
+      en: 'Actionable Card',
+      ko: '액셔너블 카드',
+    },
+    description: {
+      en: 'Combine rich account or product details with an always-visible action.',
+      ko: '계좌나 상품 정보를 액션과 함께 매끄럽게 배치합니다.',
+    },
+  },
+  {
     id: 'qr-code',
     name: {
       en: 'QR Code',


### PR DESCRIPTION
## Summary
- add the ActionableCard component with configurable layout wrappers for content and action slots
- export the new component from the library entrypoint
- document the component in the playground with a responsive demo and catalog entry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f2ef2198832c98421e34b7f24071