### PR TITLE
Refactor ActionableCard to leverage PrimeVue Card

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -11,6 +11,8 @@ export type props = {
 </script>
 
 <script setup lang="ts">
+import Card from 'primevue/card'
+
 defineOptions({
   name: 'ActionableCard',
 })
@@ -19,20 +21,33 @@ const props = withDefaults(
   defineProps<props>(),
   defaultProps
 )
+
+const cardPassThrough = {
+  root: {
+    class:
+      'overflow-hidden rounded-3xl border border-surface-200 bg-surface-0 text-surface-900 shadow-soft transition-colors',
+  },
+  body: {
+    class: 'grid grid-cols-1 p-0 sm:grid-cols-[minmax(0,1fr)_auto]',
+  },
+  content: {
+    class: 'p-0 contents',
+  },
+} as const
 </script>
 
 <template>
-  <section
-    class="grid w-full grid-cols-1 overflow-hidden rounded-3xl border border-surface-200 bg-surface-0 text-surface-900 shadow-soft transition-colors sm:grid-cols-[minmax(0,1fr)_auto]"
-  >
-    <div class="card-area flex flex-col justify-center gap-4" :class="props.cardClass">
-      <slot />
-    </div>
-    <div
-      class="flex min-h-[60px] items-stretch justify-center sm:min-h-full sm:min-w-[112px]"
-      :class="props.actionClass"
-    >
-      <slot name="action" />
-    </div>
-  </section>
+  <Card class="w-full" :pt="cardPassThrough">
+    <template #content>
+      <div class="card-area flex flex-col justify-center gap-4" :class="props.cardClass">
+        <slot />
+      </div>
+      <div
+        class="flex min-h-[60px] items-stretch justify-center sm:min-h-full sm:min-w-[112px]"
+        :class="props.actionClass"
+      >
+        <slot name="action" />
+      </div>
+    </template>
+  </Card>
 </template>


### PR DESCRIPTION
## Summary
- refactor the ActionableCard component to render through PrimeVue's Card for consistent theming
- apply pass-through styling so the card retains its responsive layout and action slot appearance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3fcd84c1c832c8d764856b0f85f38