### PR TITLE
Refactor ActionableCard to use PrimeVue Card

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -11,6 +11,9 @@ export type props = {
 </script>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import Card from 'primevue/card'
+
 defineOptions({
   name: 'ActionableCard',
 })
@@ -19,20 +22,35 @@ const props = withDefaults(
   defineProps<props>(),
   defaultProps
 )
+
+const cardPt = computed(() => ({
+  root: {
+    class:
+      'actionable-card w-full overflow-hidden rounded-3xl border border-surface-200 bg-surface-0 text-surface-900 shadow-soft transition-colors',
+  },
+  body: {
+    class: 'p-0',
+  },
+  content: {
+    class: 'p-0',
+  },
+}))
 </script>
 
 <template>
-  <section
-    class="grid w-full grid-cols-1 overflow-hidden rounded-3xl border border-surface-200 bg-surface-0 text-surface-900 shadow-soft transition-colors sm:grid-cols-[minmax(0,1fr)_auto]"
-  >
-    <div class="card-area flex flex-col justify-center gap-4" :class="props.cardClass">
-      <slot />
-    </div>
-    <div
-      class="flex min-h-[60px] items-stretch justify-center sm:min-h-full sm:min-w-[112px]"
-      :class="props.actionClass"
-    >
-      <slot name="action" />
-    </div>
-  </section>
+  <Card :pt="cardPt">
+    <template #content>
+      <div class="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto]">
+        <div class="card-area flex flex-col justify-center gap-4" :class="props.cardClass">
+          <slot />
+        </div>
+        <div
+          class="flex min-h-[60px] items-stretch justify-center sm:min-h-full sm:min-w-[112px]"
+          :class="props.actionClass"
+        >
+          <slot name="action" />
+        </div>
+      </div>
+    </template>
+  </Card>
 </template>


### PR DESCRIPTION
## Summary
- refactor the ActionableCard component to build on PrimeVue's Card while retaining customizable content and action areas
- configure pass-through styling so the new card-based layout preserves existing appearance and slot structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3fcd84c1c832c8d764856b0f85f38