### PR TITLE
Refactor ActionableCard to use PrimeVue surfaces

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -11,6 +11,11 @@ export type props = {
 </script>
 
 <script setup lang="ts">
+import Button from 'primevue/button'
+import Card from 'primevue/card'
+
+import Group from './Group.vue'
+
 defineOptions({
   name: 'ActionableCard',
 })
@@ -24,24 +29,29 @@ const props = withDefaults(defineProps<props>(), defaultProps)
 </script>
 
 <template>
-  <section
-    class="actionable-card grid w-full grid-cols-1 overflow-hidden rounded-3xl border border-surface-200 bg-surface-0 text-surface-900 shadow-soft transition-colors sm:grid-cols-[minmax(0,1fr)_auto]"
+  <Group
+    as="section"
+    class="actionable-card grid w-full grid-cols-1 rounded-3xl border border-surface-200 bg-surface-0 text-surface-900 shadow-soft transition-colors sm:grid-cols-[minmax(0,1fr)_auto]"
   >
-    <div class="card-area flex flex-col justify-center gap-4" :class="props.cardClass">
-      <slot />
-    </div>
-    <div
-      class="action-area flex min-h-[60px] items-stretch justify-center sm:min-h-full sm:min-w-[112px]"
+    <Card
+      class="card-area h-full"
+      :pt="{ content: { class: 'p-0' } }"
+    >
+      <template #content>
+        <div class="flex h-full flex-col justify-center gap-4" :class="props.cardClass">
+          <slot />
+        </div>
+      </template>
+    </Card>
+    <Button
+      unstyled
+      type="button"
+      class="action-area flex h-full min-h-[60px] w-full items-center justify-center sm:min-h-full sm:min-w-[112px]"
       :class="props.actionClass"
     >
-      <slot name="action" />
-    </div>
-  </section>
+      <span class="flex h-full w-full items-center justify-center">
+        <slot name="action" />
+      </span>
+    </Button>
+  </Group>
 </template>
-
-<style scoped>
-.action-area ::v-slotted(*) {
-  width: 100%;
-  height: 100%;
-}
-</style>

--- a/library/components/Group.vue
+++ b/library/components/Group.vue
@@ -1,0 +1,33 @@
+<script lang="ts">
+export const defaultProps = {
+  as: 'div',
+} as const
+
+export type props = {
+  as?: keyof HTMLElementTagNameMap
+}
+</script>
+
+<script setup lang="ts">
+defineOptions({
+  name: 'Group',
+})
+
+defineSlots<{
+  default: () => unknown
+}>()
+
+const props = withDefaults(defineProps<props>(), defaultProps)
+</script>
+
+<template>
+  <component :is="props.as" class="group-root overflow-hidden">
+    <slot />
+  </component>
+</template>
+
+<style scoped>
+.group-root ::v-slotted(*) {
+  border-radius: 0 !important;
+}
+</style>

--- a/library/components/index.ts
+++ b/library/components/index.ts
@@ -1,5 +1,6 @@
 export { default as ActionableCard, type props as ActionableCardProps } from './ActionableCard.vue'
 export { default as BlurOverlay, type props as BlurOverlayProps } from './BlurOverlay.vue'
+export { default as Group, type props as GroupProps } from './Group.vue'
 export { default as LoadingOverlay, type props as LoadingOverlayProps } from './LoadingOverlay.vue'
 export { default as QrCode, type props as QrCodeProps } from './QrCode.vue'
 export { default as Spinner, type props as SpinnerProps } from './Spinner.vue'

--- a/playground/src/demos/ActionableCardDemo.vue
+++ b/playground/src/demos/ActionableCardDemo.vue
@@ -52,18 +52,11 @@ const props = defineProps<ActionableCardProps>()
         </div>
       </div>
       <template #action>
-        <button
-          type="button"
-          class="flex h-full min-h-[60px] w-full items-center justify-center gap-2 px-6 text-sm font-semibold text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 bg-primary-500 hover:bg-primary-400 focus-visible:outline-primary-200 sm:min-w-[112px]"
-          aria-label="이체 정보 복사"
-        >
-          <span class="flex items-center gap-2 sm:hidden">
-            <span class="font-semibold text-white">이체 정보 복사</span>
-            <i class="pi pi-clipboard text-base text-white" aria-hidden="true"></i>
-          </span>
-          <i class="pi pi-clipboard hidden text-xl text-white sm:flex" aria-hidden="true"></i>
+        <span class="flex items-center gap-2 px-6 text-sm font-semibold">
+          <span class="sm:hidden">이체 정보 복사</span>
+          <i class="pi pi-clipboard text-lg" aria-hidden="true"></i>
           <span class="sr-only sm:not-sr-only sm:hidden">이체 정보 복사</span>
-        </button>
+        </span>
       </template>
     </ActionableCard>
   </div>

--- a/playground/src/demos/GroupDemo.vue
+++ b/playground/src/demos/GroupDemo.vue
@@ -1,0 +1,57 @@
+<script lang="ts">
+import { defaultProps as groupDefaults } from '@library/components/Group.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: groupDefaults,
+  properties: [
+    {
+      key: 'as',
+      type: 'text',
+      label: { en: 'Element tag', ko: '요소 태그' },
+      helperText: {
+        en: 'Specify which HTML element should wrap the group.',
+        ko: '그룹을 감싸는 HTML 요소를 지정합니다.',
+      },
+    },
+  ],
+}
+</script>
+
+<script setup lang="ts">
+import { Group, type GroupProps } from '@library/components'
+
+const props = defineProps<GroupProps>()
+</script>
+
+<template>
+  <div class="flex justify-center">
+    <Group
+      v-bind="props"
+      class="group-demo inline-flex divide-x divide-surface-200 rounded-2xl border border-surface-200 bg-surface-0 text-sm font-semibold text-surface-600 shadow-soft"
+      role="group"
+      aria-label="Payment frequency"
+    >
+      <button
+        type="button"
+        class="px-5 py-3 transition hover:bg-surface-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-200"
+      >
+        Monthly
+      </button>
+      <button
+        type="button"
+        class="bg-primary-600 px-5 py-3 text-white transition hover:bg-primary-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-200"
+        aria-pressed="true"
+      >
+        Quarterly
+      </button>
+      <button
+        type="button"
+        class="px-5 py-3 transition hover:bg-surface-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-200"
+      >
+        Annually
+      </button>
+    </Group>
+  </div>
+</template>
+

--- a/playground/src/demos/index.ts
+++ b/playground/src/demos/index.ts
@@ -1,11 +1,16 @@
 import ActionableCardDemo, { demoConfig as actionableCardConfig } from './ActionableCardDemo.vue'
 import BlurOverlayDemo, { demoConfig as blurOverlayConfig } from './BlurOverlayDemo.vue'
+import GroupDemo, { demoConfig as groupConfig } from './GroupDemo.vue'
 import LoadingOverlayDemo, { demoConfig as loadingOverlayConfig } from './LoadingOverlayDemo.vue'
 import QrCodeDemo, { demoConfig as qrCodeConfig } from './QrCodeDemo.vue'
 import SpinnerDemo, { demoConfig as spinnerConfig } from './SpinnerDemo.vue'
 import type { ComponentDemo } from './types'
 
 const demoEntries: Record<string, ComponentDemo> = {
+  group: {
+    component: GroupDemo,
+    ...groupConfig,
+  },
   'actionable-card': {
     component: ActionableCardDemo,
     ...actionableCardConfig,

--- a/playground/src/library/catalog.ts
+++ b/playground/src/library/catalog.ts
@@ -8,6 +8,17 @@ export interface LabComponentSummary {
 
 export const componentCatalog: LabComponentSummary[] = [
   {
+    id: 'group',
+    name: {
+      en: 'Group',
+      ko: '그룹',
+    },
+    description: {
+      en: 'Wrap adjacent elements so they behave like a single surface.',
+      ko: '인접한 요소들을 하나의 표면처럼 묶습니다.',
+    },
+  },
+  {
     id: 'actionable-card',
     name: {
       en: 'Actionable Card',


### PR DESCRIPTION
## Summary
- replace ActionableCard's custom wrappers with PrimeVue Card and Button components while retaining grouped styling
- remove redundant action-area styling now covered by the Group wrapper and PrimeVue components
- update the playground demo to feed content into the integrated Button action slot

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e481223fb8832c9871f68ebae62ce4