### PR TITLE
feat: expose corner radius control on Group

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -31,6 +31,7 @@ const props = withDefaults(defineProps<props>(), defaultProps)
 <template>
   <Group
     as="section"
+    corner-radius="1.5rem"
     class="actionable-card grid w-full grid-cols-1 rounded-3xl border border-surface-200 bg-surface-0 text-surface-900 shadow-soft transition-colors sm:grid-cols-[minmax(0,1fr)_auto]"
   >
     <Card

--- a/library/components/Group.vue
+++ b/library/components/Group.vue
@@ -1,15 +1,17 @@
 <script lang="ts">
 export const defaultProps = {
   as: 'div',
+  cornerRadius: '0px',
 } as const
 
 export type props = {
   as?: keyof HTMLElementTagNameMap
+  cornerRadius?: string
 }
 </script>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 
 defineOptions({
   name: 'Group',
@@ -22,6 +24,7 @@ defineSlots<{
 const props = withDefaults(defineProps<props>(), defaultProps)
 
 const rootRef = ref<HTMLElement | null>(null)
+const cornerRadius = computed(() => props.cornerRadius)
 
 const CORNER_CLASSES = [
   'group-corner-top-left',
@@ -203,18 +206,18 @@ onBeforeUnmount(() => {
 }
 
 .group-root ::v-slotted(.group-corner-top-left) {
-  border-top-left-radius: revert !important;
+  border-top-left-radius: v-bind(cornerRadius) !important;
 }
 
 .group-root ::v-slotted(.group-corner-top-right) {
-  border-top-right-radius: revert !important;
+  border-top-right-radius: v-bind(cornerRadius) !important;
 }
 
 .group-root ::v-slotted(.group-corner-bottom-left) {
-  border-bottom-left-radius: revert !important;
+  border-bottom-left-radius: v-bind(cornerRadius) !important;
 }
 
 .group-root ::v-slotted(.group-corner-bottom-right) {
-  border-bottom-right-radius: revert !important;
+  border-bottom-right-radius: v-bind(cornerRadius) !important;
 }
 </style>

--- a/playground/src/demos/GroupDemo.vue
+++ b/playground/src/demos/GroupDemo.vue
@@ -14,6 +14,15 @@ export const demoConfig: ComponentDemoConfig = {
         ko: '그룹을 감싸는 HTML 요소를 지정합니다.',
       },
     },
+    {
+      key: 'cornerRadius',
+      type: 'text',
+      label: { en: 'Corner radius', ko: '모서리 반경' },
+      helperText: {
+        en: 'Define the border radius applied to the outer items in the group.',
+        ko: '그룹의 바깥쪽 항목에 적용할 테두리 반경 값을 지정합니다.',
+      },
+    },
   ],
 }
 </script>


### PR DESCRIPTION
## Summary
- add a `cornerRadius` prop to the Group component and bind it in the corner styles
- update ActionableCard to forward the radius it expects for its grouped layout
- document the new prop in the Group playground demo configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4acb7f7bc832c9f65ed2c5a777e25