### PR TITLE
Fix BlurOverlay card slot forwarding

### DIFF
--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -24,17 +24,30 @@ const overlayStyle = computed(() => ({
   WebkitBackdropFilter: `blur(${props.blurStrength}px)`,
   background: props.backgroundColor,
 }))
-
-const $scopedSlots = useSlots()
+const slots = useSlots()
 </script>
 
 <template>
   <transition name="fade-blur">
-    <Card
-      class="absolute inset-0 h-full w-full rounded-inherit border-none shadow-none"
-      :style="overlayStyle"
-      v-slots="$scopedSlots"
-    />
+    <Card class="absolute inset-0 h-full w-full rounded-inherit border-none shadow-none" :style="overlayStyle">
+      <template v-if="slots.header" #header>
+        <slot name="header" />
+      </template>
+      <template v-if="slots.title" #title>
+        <slot name="title" />
+      </template>
+      <template v-if="slots.subtitle" #subtitle>
+        <slot name="subtitle" />
+      </template>
+      <template v-if="slots.content || slots.default" #content>
+        <slot name="content">
+          <slot />
+        </slot>
+      </template>
+      <template v-if="slots.footer" #footer>
+        <slot name="footer" />
+      </template>
+    </Card>
   </transition>
 </template>
 

--- a/library/components/LoadingOverlay.vue
+++ b/library/components/LoadingOverlay.vue
@@ -33,16 +33,18 @@ const props = withDefaults(defineProps<props>(), {
 
 <template>
   <BlurOverlay :blur-strength="props.overlay.blurStrength" :background-color="props.overlay.backgroundColor">
-    <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
-      <Spinner
-        :diameter="props.spinner.diameter"
-        :thickness="props.spinner.thickness"
-        :track-color="props.spinner.trackColor"
-        :indicator-color="props.spinner.indicatorColor"
-      >
-        <slot name="spinner" />
-      </Spinner>
-      <slot />
-    </div>
+    <template #content>
+      <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
+        <Spinner
+          :diameter="props.spinner.diameter"
+          :thickness="props.spinner.thickness"
+          :track-color="props.spinner.trackColor"
+          :indicator-color="props.spinner.indicatorColor"
+        >
+          <slot name="spinner" />
+        </Spinner>
+        <slot />
+      </div>
+    </template>
   </BlurOverlay>
 </template>

--- a/playground/src/demos/BlurOverlayDemo.vue
+++ b/playground/src/demos/BlurOverlayDemo.vue
@@ -36,13 +36,21 @@ defineProps<BlurOverlayProps>()
       class="absolute inset-0 w-full h-full object-cover"
     />
     <BlurOverlay v-bind="$props">
-      <div class="flex max-w-sm flex-col items-center gap-3 text-surface-0">
-        <span class="text-xs font-semibold uppercase tracking-[0.4em] text-primary-300">Focus Mode</span>
-        <h2 class="text-2xl font-semibold">Shipping polished experiences</h2>
-        <p class="text-sm text-surface-0/80">
+      <template #header>
+        <div class="flex justify-center">
+          <span class="rounded-full bg-primary-500/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-primary-200">
+            Focus Mode
+          </span>
+        </div>
+      </template>
+      <template #title>
+        <h2 class="text-2xl font-semibold text-center text-surface-0">Shipping polished experiences</h2>
+      </template>
+      <template #content>
+        <p class="mx-auto max-w-sm text-center text-sm text-surface-0/80">
           Blur surrounding distractions while presenting a focused call-to-action for your customers.
         </p>
-      </div>
+      </template>
     </BlurOverlay>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- forward PrimeVue Card slots explicitly inside BlurOverlay to restore header, title, subtitle, and footer rendering
- map the default BlurOverlay slot into the Card content slot so unnamed overlay content still displays

## Testing
- npm run build *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ca009924832cbb2071051079d17b