### PR TITLE
Align overlays with PrimeVue Card slots

### DIFF
--- a/library/components/LoadingOverlay.vue
+++ b/library/components/LoadingOverlay.vue
@@ -33,16 +33,18 @@ const props = withDefaults(defineProps<props>(), {
 
 <template>
   <BlurOverlay :blur-strength="props.overlay.blurStrength" :background-color="props.overlay.backgroundColor">
-    <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
-      <Spinner
-        :diameter="props.spinner.diameter"
-        :thickness="props.spinner.thickness"
-        :track-color="props.spinner.trackColor"
-        :indicator-color="props.spinner.indicatorColor"
-      >
-        <slot name="spinner" />
-      </Spinner>
-      <slot />
-    </div>
+    <template #content>
+      <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
+        <Spinner
+          :diameter="props.spinner.diameter"
+          :thickness="props.spinner.thickness"
+          :track-color="props.spinner.trackColor"
+          :indicator-color="props.spinner.indicatorColor"
+        >
+          <slot name="spinner" />
+        </Spinner>
+        <slot />
+      </div>
+    </template>
   </BlurOverlay>
 </template>

--- a/playground/src/demos/BlurOverlayDemo.vue
+++ b/playground/src/demos/BlurOverlayDemo.vue
@@ -36,13 +36,21 @@ defineProps<BlurOverlayProps>()
       class="absolute inset-0 w-full h-full object-cover"
     />
     <BlurOverlay v-bind="$props">
-      <div class="flex max-w-sm flex-col items-center gap-3 text-surface-0">
-        <span class="text-xs font-semibold uppercase tracking-[0.4em] text-primary-300">Focus Mode</span>
-        <h2 class="text-2xl font-semibold">Shipping polished experiences</h2>
-        <p class="text-sm text-surface-0/80">
+      <template #header>
+        <div class="flex justify-center">
+          <span class="rounded-full bg-primary-500/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-primary-200">
+            Focus Mode
+          </span>
+        </div>
+      </template>
+      <template #title>
+        <h2 class="text-2xl font-semibold text-center text-surface-0">Shipping polished experiences</h2>
+      </template>
+      <template #content>
+        <p class="mx-auto max-w-sm text-center text-sm text-surface-0/80">
           Blur surrounding distractions while presenting a focused call-to-action for your customers.
         </p>
-      </div>
+      </template>
     </BlurOverlay>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- render the loading spinner inside the BlurOverlay card content slot
- refactor the BlurOverlay demo to showcase PrimeVue Card header, title, and content slots

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e4ca009924832cbb2071051079d17b