### PR TITLE
Refactor playground UI to Element Plus components

### DIFF
--- a/playground/src/views/core/controls/field.vue
+++ b/playground/src/views/core/controls/field.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import Checkbox from 'primevue/checkbox'
-import Dropdown from 'primevue/dropdown'
-import InputText from 'primevue/inputtext'
-import Slider from 'primevue/slider'
-import Textarea from 'primevue/textarea'
-import { ElColorPicker } from 'element-plus'
+import {
+  ElCheckbox,
+  ElColorPicker,
+  ElFormItem,
+  ElInput,
+  ElOption,
+  ElSelect,
+  ElSlider,
+  ElSpace,
+  ElSwitch,
+  ElText,
+} from 'element-plus'
 import type { ControlDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 import { toRgba } from '@shared/color'
@@ -24,25 +30,16 @@ const emit = defineEmits<{
   (event: 'toggle-optional', value: boolean | undefined): void
 }>()
 
-const { t, locale } = useI18n()
+const { locale } = useI18n()
 
 const localize = (copy: LocaleCopy) => copy[locale.value as SupportedLocale] ?? copy.en
 
-const sanitizeControlKey = (key: string) => key.replace(/[^a-zA-Z0-9_-]+/g, '-')
+type SelectOption = { label: string; value: PlaygroundPropValue }
 
-const controlKey = computed(() => sanitizeControlKey(props.control.key))
-const labelId = computed(() => `${controlKey.value}-label`)
-const inputId = computed(() => `${controlKey.value}-input`)
-const toggleId = computed(() => `${controlKey.value}-toggle`)
-
-const toggleLabel = computed(() =>
-  t('playground.toggleControl', { name: localize(props.control.label) })
-)
-
-const selectOptions = computed(() =>
+const selectOptions = computed<SelectOption[]>(() =>
   (props.control.options ?? []).map((option) => ({
     label: localize(option.label),
-    value: option.value,
+    value: option.value ?? null,
   }))
 )
 
@@ -68,99 +65,79 @@ const booleanModel = computed<boolean | undefined>({
 </script>
 
 <template>
-  <div class="flex flex-col gap-2 text-sm">
-    <div v-if="isOptional" class="flex items-center gap-2">
-      <Checkbox
-        :input-id="toggleId"
-        :model-value="isActive"
-        binary
-        class="shrink-0"
-        :aria-controls="inputId"
-        :aria-expanded="isActive ? 'true' : 'false'"
-        :aria-label="toggleLabel"
-        :title="toggleLabel"
-        @update:model-value="emit('toggle-optional', $event)"
-      />
-      <label :id="labelId" :for="toggleId" class="cursor-pointer font-medium text-surface-700 dark:text-surface-200">
-        {{ localize(control.label) }}
-      </label>
-    </div>
-    <label v-else-if="control.type !== 'boolean'" :for="inputId" class="font-medium text-surface-700 dark:text-surface-200">
-      {{ localize(control.label) }}
-    </label>
-    <template v-if="control.type === 'text'">
-      <InputText
-        v-if="isActive"
-        :id="inputId"
-        v-model="stringModel"
-        :aria-labelledby="isOptional ? labelId : undefined"
-        class="w-full"
-      />
-    </template>
-    <template v-else-if="control.type === 'textarea'">
-      <Textarea
-        v-if="isActive"
-        :id="inputId"
-        v-model="stringModel"
-        rows="4"
-        auto-resize
-        :aria-labelledby="isOptional ? labelId : undefined"
-        class="w-full"
-      />
-    </template>
-    <template v-else-if="control.type === 'select'">
-      <Dropdown
-        v-if="isActive"
-        :id="inputId"
-        v-model="valueModel"
-        :options="selectOptions"
-        option-label="label"
-        option-value="value"
-        :aria-labelledby="isOptional ? labelId : undefined"
-        class="w-full"
-      />
-    </template>
-    <template v-else-if="control.type === 'color'">
-      <div v-if="isActive" class="flex items-center gap-3">
-        <ElColorPicker
-          v-model="colorModel"
-          show-alpha
-          color-format="rgb"
-          class="shrink-0"
-          :aria-labelledby="isOptional ? labelId : undefined"
-        />
-        <InputText
-          :id="inputId"
+  <template v-if="control.type === 'boolean'">
+    <ElFormItem>
+      <template #label>
+        <ElCheckbox
+          v-if="isOptional"
+          :model-value="isActive"
+          @update:model-value="(value) => emit('toggle-optional', Boolean(value))"
+        >
+          {{ localize(control.label) }}
+        </ElCheckbox>
+        <span v-else>{{ localize(control.label) }}</span>
+      </template>
+      <ElSwitch v-if="isActive" v-model="booleanModel" />
+      <ElText v-if="control.helperText && isActive" size="small" type="info">
+        {{ localize(control.helperText) }}
+      </ElText>
+    </ElFormItem>
+  </template>
+  <template v-else>
+    <ElFormItem>
+      <template #label>
+        <ElCheckbox
+          v-if="isOptional"
+          :model-value="isActive"
+          @update:model-value="(value) => emit('toggle-optional', Boolean(value))"
+        >
+          {{ localize(control.label) }}
+        </ElCheckbox>
+        <span v-else>{{ localize(control.label) }}</span>
+      </template>
+      <template v-if="control.type === 'text'">
+        <ElInput v-if="isActive" v-model="stringModel" />
+      </template>
+      <template v-else-if="control.type === 'textarea'">
+        <ElInput
+          v-if="isActive"
           v-model="stringModel"
-          :aria-labelledby="isOptional ? labelId : undefined"
-          class="flex-1"
+          type="textarea"
+          :autosize="{ minRows: 4 }"
         />
-      </div>
-    </template>
-    <template v-else-if="control.type === 'slider'">
-      <div v-if="isActive" class="flex items-center gap-3">
-        <Slider
-          :id="inputId"
+      </template>
+      <template v-else-if="control.type === 'select'">
+        <ElSelect v-if="isActive" v-model="valueModel" filterable clearable>
+          <ElOption
+            v-for="option in selectOptions"
+            :key="option.label"
+            :label="option.label"
+            :value="option.value as any"
+          />
+        </ElSelect>
+      </template>
+      <template v-else-if="control.type === 'color'">
+        <ElSpace v-if="isActive" alignment="center" wrap>
+          <ElColorPicker v-model="colorModel" show-alpha color-format="rgb" />
+          <ElInput v-model="stringModel" />
+        </ElSpace>
+      </template>
+      <template v-else-if="control.type === 'slider'">
+        <ElSlider
+          v-if="isActive"
           v-model="numberModel"
           :min="control.min ?? 0"
           :max="control.max ?? 100"
           :step="control.step ?? 1"
-          :aria-labelledby="isOptional ? labelId : undefined"
-          class="flex-1"
+          show-input
         />
-        <span class="w-12 text-right text-xs font-semibold text-primary-500">{{ numberModel ?? '' }}</span>
-      </div>
-    </template>
-    <template v-else-if="control.type === 'boolean'">
-      <div v-if="isActive" class="inline-flex items-center gap-3">
-        <Checkbox :input-id="inputId" v-model="booleanModel" binary />
-        <label :for="inputId" class="text-sm text-surface-600 dark:text-surface-300">
-          {{ localize(control.label) }}
-        </label>
-      </div>
-    </template>
-    <p v-if="control.helperText && isActive" class="text-xs text-surface-500 dark:text-surface-400">
-      {{ localize(control.helperText) }}
-    </p>
-  </div>
+      </template>
+      <template v-else>
+        <ElInput v-if="isActive" v-model="stringModel" />
+      </template>
+      <ElText v-if="control.helperText && isActive" size="small" type="info">
+        {{ localize(control.helperText) }}
+      </ElText>
+    </ElFormItem>
+  </template>
 </template>

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { ElButton, ElCard, ElDivider, ElEmpty, ElForm, ElText } from 'element-plus'
 import type { ComponentDemo } from '@/demos/types'
 import type { ControlDefinition, GroupDefinition, PlaygroundPropValue } from '@/library/types'
 import Field from './field.vue'
@@ -132,38 +133,29 @@ watch(
 </script>
 
 <template>
-  <aside class="card-surface flex h-fit flex-col gap-6 p-6">
-    <div class="flex items-center justify-between">
-      <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary-500">{{ t('playground.controls') }}</p>
-      <button type="button" class="text-xs font-semibold text-primary-500 transition hover:text-primary-400" @click="applyDefaults">
-        {{ t('playground.reset') }}
-      </button>
-    </div>
-    <p class="text-sm text-surface-500 dark:text-surface-400">{{ t('playground.helper') }}</p>
-    <form class="flex flex-col gap-6">
-      <template v-if="hasControls">
-        <div v-for="(section, sectionIndex) in controlSections" :key="section.id" class="flex flex-col gap-4">
-          <Section
-            :section="section"
-          >
-            <Field
-              v-for="control in section.controls"
-              :key="control.key"
-              :control="control"
-              v-model:value="demoProps[control.key]"
-              :is-optional="isControlOptional(control)"
-              @toggle-optional="handleOptionalToggle(control, $event)"
-            />
-          </Section>
-          <hr
-            v-if="section.group && sectionIndex < controlSections.length - 1"
-            class="border-0 border-t border-surface-200/70 dark:border-surface-700/70"
+  <ElCard>
+    <template #header>
+      <strong>{{ t('playground.controls') }}</strong>
+    </template>
+    <ElButton text size="small" type="primary" @click="applyDefaults">
+      {{ t('playground.reset') }}
+    </ElButton>
+    <ElText size="small">{{ t('playground.helper') }}</ElText>
+    <ElForm v-if="hasControls" label-position="top">
+      <template v-for="(section, sectionIndex) in controlSections" :key="section.id">
+        <Section :section="section">
+          <Field
+            v-for="control in section.controls"
+            :key="control.key"
+            :control="control"
+            v-model:value="demoProps[control.key]"
+            :is-optional="isControlOptional(control)"
+            @toggle-optional="handleOptionalToggle(control, $event)"
           />
-        </div>
+        </Section>
+        <ElDivider v-if="section.group && sectionIndex < controlSections.length - 1" />
       </template>
-      <p v-else class="text-sm text-surface-500 dark:text-surface-400">
-        {{ t('playground.noProps') }}
-      </p>
-    </form>
-  </aside>
+    </ElForm>
+    <ElEmpty v-else :description="t('playground.noProps')" />
+  </ElCard>
 </template>

--- a/playground/src/views/core/controls/section.vue
+++ b/playground/src/views/core/controls/section.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { ElCollapse, ElCollapseItem, ElSpace } from 'element-plus'
 import type { ControlDefinition, GroupDefinition, LocaleCopy } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 
@@ -11,42 +12,26 @@ const props = defineProps<{
 const { locale } = useI18n()
 
 const hasGroup = computed(() => Boolean(props.section.group))
-const isCollapsed = ref(hasGroup.value)
+const activeNames = ref<Array<string | number>>(hasGroup.value ? [] : [props.section.id])
 
-watch(
-  hasGroup,
-  (value) => {
-    if (!value) {
-      isCollapsed.value = false
-    }
-  }
-)
+watch(hasGroup, (value) => {
+  activeNames.value = value ? [] : [props.section.id]
+})
 
 const localize = (copy: LocaleCopy) => copy[locale.value as SupportedLocale] ?? copy.en
-
-const handleToggle = () => {
-  if (!hasGroup.value) {
-    return
-  }
-
-  isCollapsed.value = !isCollapsed.value
-}
 </script>
 
 <template>
-  <div class="flex flex-col gap-4">
-    <button
-      v-if="hasGroup && section.group"
-      type="button"
-      class="flex items-center justify-between text-left text-xs font-semibold uppercase tracking-[0.35em] text-surface-500 transition hover:text-primary-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-200 dark:text-surface-400"
-      :aria-expanded="isCollapsed ? 'false' : 'true'"
-      @click="handleToggle"
-    >
-      <span>{{ localize(section.group.label) }}</span>
-      <i class="pi text-sm" :class="isCollapsed ? 'pi-angle-down' : 'pi-angle-up'" aria-hidden="true"></i>
-    </button>
-    <div v-show="!hasGroup || !isCollapsed" class="flex flex-col gap-4">
+  <div>
+    <ElCollapse v-if="hasGroup && section.group" v-model="activeNames">
+      <ElCollapseItem :title="localize(section.group.label)" :name="section.id">
+        <ElSpace direction="vertical" fill>
+          <slot />
+        </ElSpace>
+      </ElCollapseItem>
+    </ElCollapse>
+    <ElSpace v-else direction="vertical" fill>
       <slot />
-    </div>
+    </ElSpace>
   </div>
 </template>

--- a/playground/src/views/core/notFound.vue
+++ b/playground/src/views/core/notFound.vue
@@ -1,23 +1,21 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { ElButton, ElResult } from 'element-plus'
 
 const { t } = useI18n()
 </script>
 
 <template>
-  <div class="card-surface flex flex-col items-center gap-5 p-10 text-center">
-    <div class="text-4xl text-primary-500">
-      <i class="pi pi-compass"></i>
-    </div>
-    <h1 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">{{ t('playground.notFoundTitle') }}</h1>
-    <p class="max-w-md text-sm text-surface-600 dark:text-surface-300">{{ t('playground.notFoundDescription') }}</p>
-    <RouterLink
-      to="/"
-      class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-medium text-primary-contrast shadow-soft transition hover:bg-primary-400"
-    >
-      {{ t('playground.backHome') }}
-      <i class="pi pi-arrow-right text-xs"></i>
-    </RouterLink>
-  </div>
+  <ElResult
+    icon="info"
+    :title="t('playground.notFoundTitle')"
+    :sub-title="t('playground.notFoundDescription')"
+  >
+    <template #extra>
+      <RouterLink to="/">
+        <ElButton type="primary">{{ t('playground.backHome') }}</ElButton>
+      </RouterLink>
+    </template>
+  </ElResult>
 </template>

--- a/playground/src/views/core/preview.vue
+++ b/playground/src/views/core/preview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { ElCard, ElDivider, ElText } from 'element-plus'
 import type { ComponentDemo } from '@/demos/types'
 import type { LabComponentSummary } from '@/library/catalog'
 import type { LocaleCopy, PlaygroundPropValue } from '@/library/types'
@@ -65,14 +66,17 @@ watch(
 </script>
 
 <template>
-  <section class="card-surface flex flex-col gap-6 p-6">
-    <header class="space-y-3">
-      <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary-500">{{ t('playground.preview') }}</p>
-      <h1 class="text-3xl font-semibold text-surface-900 dark:text-surface-0">{{ localizedName }}</h1>
-      <p class="text-sm text-surface-600 dark:text-surface-300">{{ localizedDescription }}</p>
-    </header>
-    <div class="relative min-h-[360px] overflow-hidden rounded-3xl border border-surface-200/70 bg-surface-0 p-6 shadow-inner dark:border-surface-800/70 dark:bg-surface-900">
+  <ElCard>
+    <template #header>
+      <div>
+        <ElText size="small" type="primary">{{ t('playground.preview') }}</ElText>
+        <ElText tag="h1">{{ localizedName }}</ElText>
+        <ElText>{{ localizedDescription }}</ElText>
+      </div>
+    </template>
+    <ElDivider />
+    <div style="min-height: 360px; display: flex; align-items: center; justify-content: center;">
       <component :is="demoComponent" v-bind="resolvedDemoProps" />
     </div>
-  </section>
+  </ElCard>
 </template>


### PR DESCRIPTION
## Summary
- replace bespoke playground layout with Element Plus cards, forms, and collapse panels
- update control fields to use Element Plus form inputs instead of hand-styled PrimeVue elements
- rework preview and not-found views to respect component defaults without custom styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4cb7186fc832ca7c0f824f60c8f79