### PR TITLE
Center BlurOverlay overlay content

### DIFF
--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -30,7 +30,10 @@ const overlayStyle = computed(() => ({
 
 <template>
   <transition name="fade-blur">
-    <Card class="absolute inset-0 h-full w-full rounded-inherit border-none shadow-none" :style="overlayStyle">
+    <Card
+      class="absolute inset-0 h-full w-full rounded-inherit border-none shadow-none"
+      :style="overlayStyle"
+    >
       <template v-for="(_, name) in slots" :key="name" v-slot:[name]="data">
         <slot :name="name" v-bind="data"></slot>
       </template>
@@ -51,5 +54,18 @@ const overlayStyle = computed(() => ({
 
 .rounded-inherit {
   border-radius: inherit;
+}
+
+:deep(.p-card) {
+  height: 100%;
+}
+
+:deep(.p-card-body) {
+  display: flex;
+  height: 100%;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 </style>


### PR DESCRIPTION
## Summary
- ensure the BlurOverlay card spans the full height while centering its slot content
- apply flexbox centering styles to the PrimeVue card body for both axes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e515e00464832c93076db4f71fd076