### PR TITLE
Add centering controls to BlurOverlay

### DIFF
--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -2,11 +2,15 @@
 export const defaultProps = {
   blurStrength: 7,
   backgroundColor: 'rgba(0, 0, 0, 0.25)',
+  centerVertical: true,
+  centerHorizontal: true,
 } as const
 
 export type props = {
   blurStrength?: number
   backgroundColor?: string
+  centerVertical?: boolean
+  centerHorizontal?: boolean
 }
 </script>
 
@@ -25,6 +29,8 @@ const overlayStyle = computed(() => ({
   backdropFilter: `blur(${props.blurStrength}px)`,
   WebkitBackdropFilter: `blur(${props.blurStrength}px)`,
   background: props.backgroundColor,
+  '--blur-overlay-align-items': props.centerVertical ? 'center' : 'flex-start',
+  '--blur-overlay-justify-content': props.centerHorizontal ? 'center' : 'flex-start',
 }))
 </script>
 
@@ -64,8 +70,8 @@ const overlayStyle = computed(() => ({
   display: flex;
   height: 100%;
   width: 100%;
-  align-items: center;
-  justify-content: center;
+  align-items: var(--blur-overlay-align-items);
+  justify-content: var(--blur-overlay-justify-content);
   text-align: center;
 }
 </style>


### PR DESCRIPTION
## Summary
- add optional props to toggle vertical and horizontal centering in BlurOverlay
- expose CSS variables to adjust card body alignment based on the new props

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52713b394832ca9336d2c598c6df5