### PR TITLE
Extend BlurOverlay alignment controls to demos

### DIFF
--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -2,11 +2,15 @@
 export const defaultProps = {
   blurStrength: 7,
   backgroundColor: 'rgba(0, 0, 0, 0.25)',
+  centerVertical: true,
+  centerHorizontal: true,
 } as const
 
 export type props = {
   blurStrength?: number
   backgroundColor?: string
+  centerVertical?: boolean
+  centerHorizontal?: boolean
 }
 </script>
 
@@ -25,6 +29,8 @@ const overlayStyle = computed(() => ({
   backdropFilter: `blur(${props.blurStrength}px)`,
   WebkitBackdropFilter: `blur(${props.blurStrength}px)`,
   background: props.backgroundColor,
+  '--blur-overlay-align-items': props.centerVertical ? 'center' : 'flex-start',
+  '--blur-overlay-justify-content': props.centerHorizontal ? 'center' : 'flex-start',
 }))
 </script>
 
@@ -64,8 +70,8 @@ const overlayStyle = computed(() => ({
   display: flex;
   height: 100%;
   width: 100%;
-  align-items: center;
-  justify-content: center;
+  align-items: var(--blur-overlay-align-items);
+  justify-content: var(--blur-overlay-justify-content);
   text-align: center;
 }
 </style>

--- a/library/components/LoadingOverlay.vue
+++ b/library/components/LoadingOverlay.vue
@@ -1,6 +1,11 @@
 <script lang="ts">
 export const defaultProps = {
-  overlay: {},
+  overlay: {
+    blurStrength: 7,
+    backgroundColor: 'rgba(0, 0, 0, 0.25)',
+    centerVertical: true,
+    centerHorizontal: true,
+  },
   spinner: {
     diameter: 48,
     thickness: 4,
@@ -11,6 +16,8 @@ export type props = {
   overlay?: {
     blurStrength?: number
     backgroundColor?: string
+    centerVertical?: boolean
+    centerHorizontal?: boolean
   }
   spinner?: {
     diameter?: number
@@ -32,7 +39,7 @@ const props = withDefaults(defineProps<props>(), {
 </script>
 
 <template>
-  <BlurOverlay :blur-strength="props.overlay.blurStrength" :background-color="props.overlay.backgroundColor">
+  <BlurOverlay v-bind="props.overlay">
     <template #content>
       <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
         <Spinner

--- a/playground/src/demos/BlurOverlayDemo.vue
+++ b/playground/src/demos/BlurOverlayDemo.vue
@@ -18,6 +18,16 @@ export const demoConfig: ComponentDemoConfig = {
       type: 'color',
       label: { en: 'Background Color', ko: '배경 색상' },
     },
+    {
+      key: 'centerVertical',
+      type: 'boolean',
+      label: { en: 'Center Vertically', ko: '세로 중앙 정렬' },
+    },
+    {
+      key: 'centerHorizontal',
+      type: 'boolean',
+      label: { en: 'Center Horizontally', ko: '가로 중앙 정렬' },
+    },
   ],
 }
 </script>

--- a/playground/src/demos/LoadingOverlayDemo.vue
+++ b/playground/src/demos/LoadingOverlayDemo.vue
@@ -54,6 +54,16 @@ export const demoConfig: ComponentDemoConfig = {
           type: 'color',
           label: { en: 'Background Color', ko: '배경 색상' },
         },
+        {
+          key: 'overlay.centerVertical',
+          type: 'boolean',
+          label: { en: 'Center Vertically', ko: '세로 중앙 정렬' },
+        },
+        {
+          key: 'overlay.centerHorizontal',
+          type: 'boolean',
+          label: { en: 'Center Horizontally', ko: '가로 중앙 정렬' },
+        },
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- add default alignment options to LoadingOverlay and forward them to BlurOverlay
- surface vertical and horizontal centering toggles in the BlurOverlay and LoadingOverlay playground demos

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e52713b394832ca9336d2c598c6df5