### PR TITLE
Refactor library components to the Options API

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -1,26 +1,44 @@
 <script lang="ts">
+import Button from 'primevue/button'
+import Card from 'primevue/card'
+import Group from './Group.vue'
+import { defineComponent } from 'vue'
+
 export const defaultProps = {
+  cardClass: undefined,
+  actionClass: undefined,
 } as const
 
 export type props = {
   cardClass?: string
   actionClass?: string
 }
-</script>
 
-<script setup lang="ts">
-import Button from 'primevue/button'
-import Card from 'primevue/card'
-import Group from './Group.vue'
-
-const props = withDefaults(defineProps<props>(), defaultProps)
+export default defineComponent({
+  name: 'ActionableCard',
+  components: {
+    Button,
+    Card,
+    Group,
+  },
+  props: {
+    cardClass: {
+      type: String,
+      default: defaultProps.cardClass,
+    },
+    actionClass: {
+      type: String,
+      default: defaultProps.actionClass,
+    },
+  },
+})
 </script>
 
 <template>
   <Group class="grid w-full grid-cols-1 rounded-md shadow-soft transition-colors sm:grid-cols-[minmax(0,1fr)_auto]">
     <Card class="h-full">
       <template #content>
-        <div class="flex h-full flex-col justify-center gap-4" :class="props.cardClass">
+        <div class="flex h-full flex-col justify-center gap-4" :class="cardClass">
           <slot />
         </div>
       </template>
@@ -28,7 +46,7 @@ const props = withDefaults(defineProps<props>(), defaultProps)
     <Button
       type="button"
       class="flex h-full min-h-[60px] w-full items-center justify-center sm:min-h-full sm:min-w-[112px]"
-      :class="props.actionClass"
+      :class="actionClass"
     >
       <span class="flex h-full w-full items-center justify-center">
         <slot name="action" />

--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -1,4 +1,7 @@
 <script lang="ts">
+import Card from 'primevue/card'
+import { defineComponent } from 'vue'
+
 export const defaultProps = {
   blurStrength: 7,
   backgroundColor: 'rgba(0, 0, 0, 0.25)',
@@ -12,26 +15,42 @@ export type props = {
   centerVertical?: boolean
   centerHorizontal?: boolean
 }
-</script>
 
-<script setup lang="ts">
-import Card from 'primevue/card'
-import { computed, useSlots } from 'vue'
+export default defineComponent({
+  name: 'BlurOverlay',
+  components: { Card },
+  props: {
+    blurStrength: {
+      type: Number,
+      default: defaultProps.blurStrength,
+    },
+    backgroundColor: {
+      type: String,
+      default: defaultProps.backgroundColor,
+    },
+    centerVertical: {
+      type: Boolean,
+      default: defaultProps.centerVertical,
+    },
+    centerHorizontal: {
+      type: Boolean,
+      default: defaultProps.centerHorizontal,
+    },
+  },
+  computed: {
+    overlayStyle(): Record<string, string> {
+      const blur = `blur(${this.blurStrength}px)`
 
-const props = withDefaults(
-  defineProps<props>(),
-  defaultProps
-)
-
-const slots = useSlots()
-
-const overlayStyle = computed(() => ({
-  backdropFilter: `blur(${props.blurStrength}px)`,
-  WebkitBackdropFilter: `blur(${props.blurStrength}px)`,
-  background: props.backgroundColor,
-  '--blur-overlay-align-items': props.centerVertical ? 'center' : 'flex-start',
-  '--blur-overlay-justify-content': props.centerHorizontal ? 'center' : 'flex-start',
-}))
+      return {
+        backdropFilter: blur,
+        WebkitBackdropFilter: blur,
+        background: this.backgroundColor,
+        '--blur-overlay-align-items': this.centerVertical ? 'center' : 'flex-start',
+        '--blur-overlay-justify-content': this.centerHorizontal ? 'center' : 'flex-start',
+      }
+    },
+  },
+})
 </script>
 
 <template>
@@ -40,8 +59,8 @@ const overlayStyle = computed(() => ({
       class="absolute inset-0 h-full w-full rounded-inherit border-none shadow-none"
       :style="overlayStyle"
     >
-      <template v-for="(_, name) in slots" :key="name" v-slot:[name]="data">
-        <slot :name="name" v-bind="data"></slot>
+      <template v-for="(_, name) in $slots" :key="name" v-slot:[name]="data">
+        <slot :name="name" v-bind="data" />
       </template>
     </Card>
   </transition>

--- a/library/components/Group.vue
+++ b/library/components/Group.vue
@@ -1,21 +1,10 @@
 <script lang="ts">
+import { defineComponent } from 'vue'
+
 export const defaultProps = {} as const
 
 export type props = {}
-</script>
 
-<script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
-
-defineOptions({
-  name: 'Group',
-})
-
-defineSlots<{
-  default: () => unknown
-}>()
-
-const rootRef = ref<HTMLElement | null>(null)
 const CORNER_CLASSES = [
   'group-corner-top-left',
   'group-corner-top-right',
@@ -23,169 +12,156 @@ const CORNER_CLASSES = [
   'group-corner-bottom-right',
 ] as const
 
-const scheduleUpdate = (() => {
-  if (typeof window === 'undefined') {
-    return () => undefined
+const EPSILON = 1
+
+type CornerEntry = {
+  child: HTMLElement
+  rect: DOMRect
+}
+
+const isHTMLElement = (element: Element): element is HTMLElement => element instanceof HTMLElement
+
+const resetCornerMarkers = (child: HTMLElement) => {
+  child.classList.add('group-item')
+
+  for (const corner of CORNER_CLASSES) {
+    child.classList.remove(corner)
   }
+}
 
-  let frame = 0
+const pickClosestEntries = (
+  entries: CornerEntry[],
+  target: number,
+  projector: (rect: DOMRect) => number
+) => entries.filter(({ rect }) => Math.abs(projector(rect) - target) <= EPSILON)
 
-  const updateCornerRadius = () => {
-    const root = rootRef.value
+const pickExtremeEntry = (
+  entries: CornerEntry[],
+  projector: (rect: DOMRect) => number,
+  isBetter: (candidate: number, current: number) => boolean
+): CornerEntry | undefined =>
+  entries.reduce<CornerEntry | undefined>((best, entry) => {
+    if (!best) return entry
 
-    if (!root) return
+    return isBetter(projector(entry.rect), projector(best.rect)) ? entry : best
+  }, undefined)
 
-    const children = Array.from(root.children).filter(
-      (child): child is HTMLElement => child instanceof HTMLElement,
-    )
+const markCorner = (entry: CornerEntry | undefined, className: (typeof CORNER_CLASSES)[number]) => {
+  entry?.child.classList.add(className)
+}
 
-    if (!children.length) return
+export default defineComponent({
+  name: 'Group',
+  data() {
+    return {
+      frame: 0,
+      observer: null as MutationObserver | null,
+      resizeObserver: null as ResizeObserver | null,
+    }
+  },
+  methods: {
+    scheduleUpdate(): void {
+      if (typeof window === 'undefined') return
 
-    const entries = children.map((child) => {
-      child.classList.add('group-item')
+      window.cancelAnimationFrame(this.frame)
+      this.frame = window.requestAnimationFrame(() => this.updateCornerRadius())
+    },
+    updateCornerRadius(): void {
+      const root = this.$refs.root as HTMLElement | undefined
 
-      for (const cornerClass of CORNER_CLASSES) {
-        child.classList.remove(cornerClass)
+      if (!root) return
+
+      const children = Array.from(root.children).filter(isHTMLElement)
+
+      if (!children.length) return
+
+      const entries = children.map<CornerEntry>((child) => {
+        resetCornerMarkers(child)
+        return { child, rect: child.getBoundingClientRect() }
+      })
+
+      const topMost = Math.min(...entries.map(({ rect }) => rect.top))
+      const bottomMost = Math.max(...entries.map(({ rect }) => rect.bottom))
+      const leftMost = Math.min(...entries.map(({ rect }) => rect.left))
+      const rightMost = Math.max(...entries.map(({ rect }) => rect.right))
+
+      const topRow = pickClosestEntries(entries, topMost, (rect) => rect.top)
+      const bottomRow = pickClosestEntries(entries, bottomMost, (rect) => rect.bottom)
+      const leftColumn = pickClosestEntries(entries, leftMost, (rect) => rect.left)
+      const rightColumn = pickClosestEntries(entries, rightMost, (rect) => rect.right)
+
+      const topLeft = pickExtremeEntry(topRow, (rect) => rect.left, (candidate, current) => candidate < current)
+      const topRight = pickExtremeEntry(topRow, (rect) => rect.right, (candidate, current) => candidate > current)
+      const bottomLeft = pickExtremeEntry(bottomRow, (rect) => rect.left, (candidate, current) => candidate < current)
+      const bottomRight = pickExtremeEntry(bottomRow, (rect) => rect.right, (candidate, current) => candidate > current)
+
+      const ensureColumnCorners = (
+        columnEntries: CornerEntry[],
+        topClass: (typeof CORNER_CLASSES)[number],
+        bottomClass: (typeof CORNER_CLASSES)[number]
+      ) => {
+        if (!columnEntries.length) return
+
+        const top = pickExtremeEntry(columnEntries, (rect) => rect.top, (candidate, current) => candidate < current)
+        const bottom = pickExtremeEntry(columnEntries, (rect) => rect.bottom, (candidate, current) => candidate > current)
+
+        markCorner(top, topClass)
+        markCorner(bottom, bottomClass)
       }
 
-      return { child, rect: child.getBoundingClientRect() }
-    })
+      markCorner(topLeft, 'group-corner-top-left')
+      markCorner(topRight, 'group-corner-top-right')
+      markCorner(bottomLeft, 'group-corner-bottom-left')
+      markCorner(bottomRight, 'group-corner-bottom-right')
 
-    const EPSILON = 1
+      if (!topLeft || !bottomLeft) {
+        ensureColumnCorners(leftColumn, 'group-corner-top-left', 'group-corner-bottom-left')
+      }
 
-    const topMost = Math.min(...entries.map(({ rect }) => rect.top))
-    const bottomMost = Math.max(...entries.map(({ rect }) => rect.bottom))
-    const leftMost = Math.min(...entries.map(({ rect }) => rect.left))
-    const rightMost = Math.max(...entries.map(({ rect }) => rect.right))
+      if (!topRight || !bottomRight) {
+        ensureColumnCorners(rightColumn, 'group-corner-top-right', 'group-corner-bottom-right')
+      }
+    },
+    handleStructuralChange(): void {
+      this.scheduleUpdate()
+    },
+    cleanupObservers(): void {
+      this.observer?.disconnect()
+      this.observer = null
 
-    const topRow = entries.filter(({ rect }) => rect.top - topMost <= EPSILON)
-    const bottomRow = entries.filter(({ rect }) => bottomMost - rect.bottom <= EPSILON)
-    const leftColumn = entries.filter(({ rect }) => rect.left - leftMost <= EPSILON)
-    const rightColumn = entries.filter(({ rect }) => rightMost - rect.right <= EPSILON)
+      this.resizeObserver?.disconnect()
+      this.resizeObserver = null
+    },
+  },
+  mounted() {
+    this.scheduleUpdate()
 
-    const topLeft = topRow.reduce((candidate, entry) => {
-      if (!candidate || entry.rect.left < candidate.rect.left) return entry
+    const root = this.$refs.root as HTMLElement | undefined
 
-      return candidate
-    }, undefined as (typeof entries)[number] | undefined)
+    if (!root || typeof window === 'undefined') return
 
-    const topRight = topRow.reduce((candidate, entry) => {
-      if (!candidate || entry.rect.right > candidate.rect.right) return entry
+    this.observer = new MutationObserver(() => this.handleStructuralChange())
+    this.observer.observe(root, { childList: true })
 
-      return candidate
-    }, undefined as (typeof entries)[number] | undefined)
-
-    const bottomLeft = bottomRow.reduce((candidate, entry) => {
-      if (!candidate || entry.rect.left < candidate.rect.left) return entry
-
-      return candidate
-    }, undefined as (typeof entries)[number] | undefined)
-
-    const bottomRight = bottomRow.reduce((candidate, entry) => {
-      if (!candidate || entry.rect.right > candidate.rect.right) return entry
-
-      return candidate
-    }, undefined as (typeof entries)[number] | undefined)
-
-    const assignCorner = (
-      entry: (typeof entries)[number] | undefined,
-      className: (typeof CORNER_CLASSES)[number],
-    ) => {
-      if (!entry) return
-
-      entry.child.classList.add(className)
+    if (typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(() => this.handleStructuralChange())
+      this.resizeObserver.observe(root)
     }
 
-    const addLeftColumnCorners = () => {
-      const leftTop = leftColumn.reduce((candidate, entry) => {
-        if (!candidate || entry.rect.top < candidate.rect.top) return entry
+    window.addEventListener('resize', this.scheduleUpdate)
+  },
+  beforeUnmount() {
+    if (typeof window === 'undefined') return
 
-        return candidate
-      }, undefined as (typeof entries)[number] | undefined)
-
-      const leftBottom = leftColumn.reduce((candidate, entry) => {
-        if (!candidate || entry.rect.bottom > candidate.rect.bottom) return entry
-
-        return candidate
-      }, undefined as (typeof entries)[number] | undefined)
-
-      assignCorner(leftTop, 'group-corner-top-left')
-      assignCorner(leftBottom, 'group-corner-bottom-left')
-    }
-
-    const addRightColumnCorners = () => {
-      const rightTop = rightColumn.reduce((candidate, entry) => {
-        if (!candidate || entry.rect.top < candidate.rect.top) return entry
-
-        return candidate
-      }, undefined as (typeof entries)[number] | undefined)
-
-      const rightBottom = rightColumn.reduce((candidate, entry) => {
-        if (!candidate || entry.rect.bottom > candidate.rect.bottom) return entry
-
-        return candidate
-      }, undefined as (typeof entries)[number] | undefined)
-
-      assignCorner(rightTop, 'group-corner-top-right')
-      assignCorner(rightBottom, 'group-corner-bottom-right')
-    }
-
-    assignCorner(topLeft, 'group-corner-top-left')
-    assignCorner(topRight, 'group-corner-top-right')
-    assignCorner(bottomLeft, 'group-corner-bottom-left')
-    assignCorner(bottomRight, 'group-corner-bottom-right')
-
-    if (!topLeft && leftColumn.length) addLeftColumnCorners()
-    if (!bottomLeft && leftColumn.length) addLeftColumnCorners()
-    if (!topRight && rightColumn.length) addRightColumnCorners()
-    if (!bottomRight && rightColumn.length) addRightColumnCorners()
-  }
-
-  const schedule = () => {
-    window.cancelAnimationFrame(frame)
-    frame = window.requestAnimationFrame(updateCornerRadius)
-  }
-
-  return schedule
-})()
-
-let observer: MutationObserver | null = null
-let resizeObserver: ResizeObserver | null = null
-
-onMounted(() => {
-  scheduleUpdate()
-
-  const root = rootRef.value
-
-  if (!root || typeof window === 'undefined') return
-
-  observer = new MutationObserver(() => scheduleUpdate())
-
-  observer.observe(root, { childList: true })
-
-  if (typeof ResizeObserver !== 'undefined') {
-    resizeObserver = new ResizeObserver(() => scheduleUpdate())
-    resizeObserver.observe(root)
-  }
-
-  window.addEventListener('resize', scheduleUpdate)
-})
-
-onBeforeUnmount(() => {
-  if (typeof window === 'undefined') return
-
-  observer?.disconnect()
-  observer = null
-
-  resizeObserver?.disconnect()
-  resizeObserver = null
-
-  window.removeEventListener('resize', scheduleUpdate)
+    window.cancelAnimationFrame(this.frame)
+    this.cleanupObservers()
+    window.removeEventListener('resize', this.scheduleUpdate)
+  },
 })
 </script>
 
 <template>
-  <div ref="rootRef" class="group-root">
+  <div ref="root" class="group-root">
     <slot />
   </div>
 </template>

--- a/library/components/LoadingOverlay.vue
+++ b/library/components/LoadingOverlay.vue
@@ -1,4 +1,8 @@
 <script lang="ts">
+import BlurOverlay from './BlurOverlay.vue'
+import Spinner from './Spinner.vue'
+import { defineComponent, type PropType } from 'vue'
+
 export const defaultProps = {
   overlay: {
     blurStrength: 7,
@@ -26,27 +30,38 @@ export type props = {
     indicatorColor?: string
   }
 }
-</script>
 
-<script setup lang="ts">
-import BlurOverlay from './BlurOverlay.vue'
-import Spinner from './Spinner.vue'
+type OverlayConfig = NonNullable<props['overlay']>
+type SpinnerConfig = NonNullable<props['spinner']>
 
-const props = withDefaults(defineProps<props>(), {
-  overlay: () => ({ ...defaultProps.overlay }),
-  spinner: () => ({ ...defaultProps.spinner }),
+export default defineComponent({
+  name: 'LoadingOverlay',
+  components: {
+    BlurOverlay,
+    Spinner,
+  },
+  props: {
+    overlay: {
+      type: Object as PropType<OverlayConfig>,
+      default: () => ({ ...defaultProps.overlay }),
+    },
+    spinner: {
+      type: Object as PropType<SpinnerConfig>,
+      default: () => ({ ...defaultProps.spinner }),
+    },
+  },
 })
 </script>
 
 <template>
-  <BlurOverlay v-bind="props.overlay">
+  <BlurOverlay v-bind="overlay">
     <template #content>
       <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
         <Spinner
-          :diameter="props.spinner.diameter"
-          :thickness="props.spinner.thickness"
-          :track-color="props.spinner.trackColor"
-          :indicator-color="props.spinner.indicatorColor"
+          :diameter="spinner?.diameter"
+          :thickness="spinner?.thickness"
+          :track-color="spinner?.trackColor"
+          :indicator-color="spinner?.indicatorColor"
         >
           <slot name="spinner" />
         </Spinner>

--- a/library/components/QrCode.vue
+++ b/library/components/QrCode.vue
@@ -1,4 +1,8 @@
 <script lang="ts">
+import QRCode from 'qrcode'
+import { toHex } from '@shared/color'
+import { defineComponent } from 'vue'
+
 export const defaultProps = {
   data: window.location.href,
   lightColor: 'white',
@@ -10,52 +14,64 @@ export type props = {
   lightColor?: string
   darkColor?: string
 }
-</script>
 
-<script setup lang="ts">
-import { ref, watch } from 'vue'
-import QRCode from 'qrcode'
-import { toHex } from '@shared/color'
-
-const props = withDefaults(
-  defineProps<props>(),
-  defaultProps
-)
-
-const qrSource = ref('')
-const qrError = ref('')
-  
-const updateQrCode = () => {
-  const darkHex = toHex(props.darkColor) || '#000000'
-  const lightHex = toHex(props.lightColor) || '#ffffff'
-
-  QRCode.toDataURL(
-    props.data,
-    {
-      margin: 0,
-      color: {
-        dark: darkHex,
-        light: lightHex,
-      },
+export default defineComponent({
+  name: 'QrCode',
+  props: {
+    data: {
+      type: String,
+      default: defaultProps.data,
     },
-    (error: Error | null | undefined, url: string) => {
-      if (error) {
-        qrError.value = String(error)
-        return
-      }
-
-      qrSource.value = url
-      qrError.value = ''
+    lightColor: {
+      type: String,
+      default: defaultProps.lightColor,
+    },
+    darkColor: {
+      type: String,
+      default: defaultProps.darkColor,
+    },
+  },
+  data() {
+    return {
+      qrSource: '',
+      qrError: '',
     }
-  )
-}
+  },
+  watch: {
+    data: 'updateQrCode',
+    lightColor: 'updateQrCode',
+    darkColor: 'updateQrCode',
+  },
+  created() {
+    this.updateQrCode()
+  },
+  methods: {
+    updateQrCode(): void {
+      const darkHex = toHex(this.darkColor) || '#000000'
+      const lightHex = toHex(this.lightColor) || '#ffffff'
 
-watch(
-  () => [props.data, props.darkColor, props.lightColor],
-  updateQrCode
-)
+      QRCode.toDataURL(
+        this.data,
+        {
+          margin: 0,
+          color: {
+            dark: darkHex,
+            light: lightHex,
+          },
+        },
+        (error: Error | null | undefined, url: string) => {
+          if (error) {
+            this.qrError = String(error)
+            return
+          }
 
-updateQrCode()
+          this.qrSource = url
+          this.qrError = ''
+        }
+      )
+    },
+  },
+})
 </script>
 
 <template>

--- a/library/components/Spinner.vue
+++ b/library/components/Spinner.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { defineComponent } from 'vue'
+
 export const defaultProps = {
   diameter: 96,
   thickness: 8,
@@ -10,28 +12,41 @@ export type props = {
   trackColor?: string
   indicatorColor?: string
 }
-</script>
 
-<script setup lang="ts">
-import { computed } from 'vue'
+const FALLBACK_TRACK_COLOR = 'color-mix(in srgb, currentColor 35%, transparent)'
 
-const props = withDefaults(
-  defineProps<props>(),
-  defaultProps
-)
+export default defineComponent({
+  name: 'Spinner',
+  props: {
+    diameter: {
+      type: Number,
+      default: defaultProps.diameter,
+    },
+    thickness: {
+      type: Number,
+      default: defaultProps.thickness,
+    },
+    trackColor: String,
+    indicatorColor: String,
+  },
+  computed: {
+    dimensions(): Record<string, string> {
+      const diameter = `${this.diameter}px`
 
-const dimensions = computed(() => ({
-  width: `${props.diameter}px`,
-  height: `${props.diameter}px`,
-}))
-
-const fallbackTrackColor = 'color-mix(in srgb, currentColor 35%, transparent)'
-
-const ringStyle = computed(() => ({
-  borderWidth: `${props.thickness}px`,
-  borderColor: props.trackColor ?? fallbackTrackColor,
-  borderTopColor: props.indicatorColor ?? 'currentColor',
-}))
+      return {
+        width: diameter,
+        height: diameter,
+      }
+    },
+    ringStyle(): Record<string, string> {
+      return {
+        borderWidth: `${this.thickness}px`,
+        borderColor: this.trackColor ?? FALLBACK_TRACK_COLOR,
+        borderTopColor: this.indicatorColor ?? 'currentColor',
+      }
+    },
+  },
+})
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- migrate the library Vue components from `<script setup>` composition API to the classic Options API
- clean up the Group corner calculation logic with focused helpers and reusable observers
- preserve exported default props so the playground demos continue to surface defaults

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5e01da874832c9cc39ed9a61fefa1