### PR TITLE
fix: align loading overlay with blur overlay slot change

### DIFF
--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -53,7 +53,7 @@ export default defineComponent({
 
 <template>
   <transition name="fade-blur">
-    <div class="blur-overlay absolute inset-0 h-full w-full rounded-inherit" :style="overlayStyle">
+    <div class="blur-overlay flex absolute inset-0 h-full w-full rounded-inherit" :style="overlayStyle">
       <slot />
     </div>
   </transition>
@@ -75,9 +75,6 @@ export default defineComponent({
 }
 
 .blur-overlay {
-  display: flex;
-  height: 100%;
-  width: 100%;
   align-items: var(--blur-overlay-align-items);
   justify-content: var(--blur-overlay-justify-content);
 }

--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-import Card from 'primevue/card'
 import { defineComponent } from 'vue'
 
 export const defaultProps = {
@@ -18,7 +17,6 @@ export type props = {
 
 export default defineComponent({
   name: 'BlurOverlay',
-  components: { Card },
   props: {
     blurStrength: {
       type: Number,
@@ -55,14 +53,9 @@ export default defineComponent({
 
 <template>
   <transition name="fade-blur">
-    <Card
-      class="absolute inset-0 h-full w-full rounded-inherit border-none shadow-none"
-      :style="overlayStyle"
-    >
-      <template v-for="(_, name) in $slots" :key="name" v-slot:[name]="data">
-        <slot :name="name" v-bind="data" />
-      </template>
-    </Card>
+    <div class="blur-overlay absolute inset-0 h-full w-full rounded-inherit" :style="overlayStyle">
+      <slot />
+    </div>
   </transition>
 </template>
 
@@ -81,11 +74,7 @@ export default defineComponent({
   border-radius: inherit;
 }
 
-:deep(.p-card) {
-  height: 100%;
-}
-
-:deep(.p-card-body) {
+.blur-overlay {
   display: flex;
   height: 100%;
   width: 100%;

--- a/library/components/LoadingOverlay.vue
+++ b/library/components/LoadingOverlay.vue
@@ -37,18 +37,16 @@ export default defineComponent({
 
 <template>
   <BlurOverlay v-bind="overlay">
-    <template #content>
-      <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
-        <Spinner
-          :diameter="spinner?.diameter"
-          :thickness="spinner?.thickness"
-          :track-color="spinner?.trackColor"
-          :indicator-color="spinner?.indicatorColor"
-        >
-          <slot name="spinner" />
-        </Spinner>
-        <slot />
-      </div>
-    </template>
+    <div class="flex flex-col items-center gap-4 text-center text-surface-0" aria-live="polite">
+      <Spinner
+        :diameter="spinner?.diameter"
+        :thickness="spinner?.thickness"
+        :track-color="spinner?.trackColor"
+        :indicator-color="spinner?.indicatorColor"
+      >
+        <slot name="spinner" />
+      </Spinner>
+      <slot />
+    </div>
   </BlurOverlay>
 </template>

--- a/playground/src/demos/BlurOverlayDemo.vue
+++ b/playground/src/demos/BlurOverlayDemo.vue
@@ -46,19 +46,15 @@ defineProps<BlurOverlayProps>()
       class="absolute inset-0 w-full h-full object-cover"
     />
     <BlurOverlay v-bind="$props">
-      <template #header>
+      <div class="mx-auto flex max-w-sm flex-col items-center gap-4 text-center text-surface-0">
         <span class="text-xs font-semibold uppercase tracking-[0.4em] text-primary-200">
           Focus Mode
         </span>
-      </template>
-      <template #title>
         <h2 class="text-2xl font-semibold">Shipping polished experiences</h2>
-      </template>
-      <template #content>
-        <p class="mx-auto max-w-sm text-sm">
+        <p class="text-sm">
           Blur surrounding distractions while presenting a focused call-to-action for your customers.
         </p>
-      </template>
+      </div>
     </BlurOverlay>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- update LoadingOverlay to consume BlurOverlay through the default slot only
- refresh the BlurOverlay playground demo markup for the single-slot API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5f6e58a70832cadf3ba2910dc13ca