### PR TITLE
Refactor playground layout to rely on PrimeVue components

### DIFF
--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Card from 'primevue/card'
+import Button from 'primevue/button'
+import Divider from 'primevue/divider'
 import type { ComponentDemo } from '@/demos/types'
 import type { ControlDefinition, GroupDefinition, PlaygroundPropValue } from '@/library/types'
 import Field from './field.vue'
@@ -132,38 +135,46 @@ watch(
 </script>
 
 <template>
-  <aside class="card-surface flex h-fit flex-col gap-6 p-6">
-    <div class="flex items-center justify-between">
-      <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary-500">{{ t('playground.controls') }}</p>
-      <button type="button" class="text-xs font-semibold text-primary-500 transition hover:text-primary-400" @click="applyDefaults">
-        {{ t('playground.reset') }}
-      </button>
-    </div>
-    <p class="text-sm text-surface-500 dark:text-surface-400">{{ t('playground.helper') }}</p>
-    <form class="flex flex-col gap-6">
-      <template v-if="hasControls">
-        <div v-for="(section, sectionIndex) in controlSections" :key="section.id" class="flex flex-col gap-4">
-          <Section
-            :section="section"
+  <Card class="h-fit">
+    <template #title>
+      <div class="flex items-center justify-between gap-3">
+        <span>{{ t('playground.controls') }}</span>
+        <Button
+          type="button"
+          :label="t('playground.reset')"
+          size="small"
+          severity="secondary"
+          text
+          @click="applyDefaults"
+        />
+      </div>
+    </template>
+    <template #subtitle>
+      <span>{{ t('playground.helper') }}</span>
+    </template>
+    <template #content>
+      <form class="flex flex-col gap-4">
+        <template v-if="hasControls">
+          <div
+            v-for="(section, sectionIndex) in controlSections"
+            :key="section.id"
+            class="flex flex-col gap-4"
           >
-            <Field
-              v-for="control in section.controls"
-              :key="control.key"
-              :control="control"
-              v-model:value="demoProps[control.key]"
-              :is-optional="isControlOptional(control)"
-              @toggle-optional="handleOptionalToggle(control, $event)"
-            />
-          </Section>
-          <hr
-            v-if="section.group && sectionIndex < controlSections.length - 1"
-            class="border-0 border-t border-surface-200/70 dark:border-surface-700/70"
-          />
-        </div>
-      </template>
-      <p v-else class="text-sm text-surface-500 dark:text-surface-400">
-        {{ t('playground.noProps') }}
-      </p>
-    </form>
-  </aside>
+            <Section :section="section">
+              <Field
+                v-for="control in section.controls"
+                :key="control.key"
+                :control="control"
+                v-model:value="demoProps[control.key]"
+                :is-optional="isControlOptional(control)"
+                @toggle-optional="handleOptionalToggle(control, $event)"
+              />
+            </Section>
+            <Divider v-if="section.group && sectionIndex < controlSections.length - 1" />
+          </div>
+        </template>
+        <p v-else>{{ t('playground.noProps') }}</p>
+      </form>
+    </template>
+  </Card>
 </template>

--- a/playground/src/views/core/controls/section.vue
+++ b/playground/src/views/core/controls/section.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Panel from 'primevue/panel'
 import type { ControlDefinition, GroupDefinition, LocaleCopy } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 
@@ -24,28 +25,21 @@ watch(
 
 const localize = (copy: LocaleCopy) => copy[locale.value as SupportedLocale] ?? copy.en
 
-const handleToggle = () => {
-  if (!hasGroup.value) {
-    return
-  }
-
-  isCollapsed.value = !isCollapsed.value
-}
 </script>
 
 <template>
   <div class="flex flex-col gap-4">
-    <button
+    <Panel
       v-if="hasGroup && section.group"
-      type="button"
-      class="flex items-center justify-between text-left text-xs font-semibold uppercase tracking-[0.35em] text-surface-500 transition hover:text-primary-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-200 dark:text-surface-400"
-      :aria-expanded="isCollapsed ? 'false' : 'true'"
-      @click="handleToggle"
+      toggleable
+      v-model:collapsed="isCollapsed"
+      :header="localize(section.group.label)"
     >
-      <span>{{ localize(section.group.label) }}</span>
-      <i class="pi text-sm" :class="isCollapsed ? 'pi-angle-down' : 'pi-angle-up'" aria-hidden="true"></i>
-    </button>
-    <div v-show="!hasGroup || !isCollapsed" class="flex flex-col gap-4">
+      <div class="flex flex-col gap-4">
+        <slot />
+      </div>
+    </Panel>
+    <div v-else class="flex flex-col gap-4">
       <slot />
     </div>
   </div>

--- a/playground/src/views/core/notFound.vue
+++ b/playground/src/views/core/notFound.vue
@@ -1,23 +1,25 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import Card from 'primevue/card'
+import Button from 'primevue/button'
 
 const { t } = useI18n()
 </script>
 
 <template>
-  <div class="card-surface flex flex-col items-center gap-5 p-10 text-center">
-    <div class="text-4xl text-primary-500">
-      <i class="pi pi-compass"></i>
-    </div>
-    <h1 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">{{ t('playground.notFoundTitle') }}</h1>
-    <p class="max-w-md text-sm text-surface-600 dark:text-surface-300">{{ t('playground.notFoundDescription') }}</p>
-    <RouterLink
-      to="/"
-      class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-medium text-primary-contrast shadow-soft transition hover:bg-primary-400"
-    >
-      {{ t('playground.backHome') }}
-      <i class="pi pi-arrow-right text-xs"></i>
-    </RouterLink>
-  </div>
+  <Card class="text-center">
+    <template #content>
+      <div class="flex flex-col items-center gap-4">
+        <div class="text-4xl text-primary-500">
+          <i class="pi pi-compass"></i>
+        </div>
+        <h1>{{ t('playground.notFoundTitle') }}</h1>
+        <p>{{ t('playground.notFoundDescription') }}</p>
+        <RouterLink to="/">
+          <Button :label="t('playground.backHome')" icon="pi pi-arrow-right" icon-pos="right" />
+        </RouterLink>
+      </div>
+    </template>
+  </Card>
 </template>

--- a/playground/src/views/core/preview.vue
+++ b/playground/src/views/core/preview.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Card from 'primevue/card'
+import Panel from 'primevue/panel'
 import type { ComponentDemo } from '@/demos/types'
 import type { LabComponentSummary } from '@/library/catalog'
 import type { LocaleCopy, PlaygroundPropValue } from '@/library/types'
@@ -65,14 +67,20 @@ watch(
 </script>
 
 <template>
-  <section class="card-surface flex flex-col gap-6 p-6">
-    <header class="space-y-3">
-      <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary-500">{{ t('playground.preview') }}</p>
-      <h1 class="text-3xl font-semibold text-surface-900 dark:text-surface-0">{{ localizedName }}</h1>
-      <p class="text-sm text-surface-600 dark:text-surface-300">{{ localizedDescription }}</p>
-    </header>
-    <div class="relative min-h-[360px] overflow-hidden rounded-3xl border border-surface-200/70 bg-surface-0 p-6 shadow-inner dark:border-surface-800/70 dark:bg-surface-900">
-      <component :is="demoComponent" v-bind="resolvedDemoProps" />
-    </div>
-  </section>
+  <Card>
+    <template #header>
+      <span>{{ t('playground.preview') }}</span>
+    </template>
+    <template #title>
+      {{ localizedName }}
+    </template>
+    <template #subtitle>
+      {{ localizedDescription }}
+    </template>
+    <template #content>
+      <Panel>
+        <component :is="demoComponent" v-bind="resolvedDemoProps" />
+      </Panel>
+    </template>
+  </Card>
 </template>


### PR DESCRIPTION
## Summary
- replace the playground controls wrapper with PrimeVue Card, Button, and Divider
- use a toggleable PrimeVue Panel for grouped control sections and wrap the preview with Card and Panel
- render the not found state with PrimeVue components instead of custom markup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5ff2094f0832cb09c54aa69e98c47