### PR TITLE
Refactor playground shell to PrimeVue components

### DIFF
--- a/playground/src/views/HomePage.vue
+++ b/playground/src/views/HomePage.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import Button from 'primevue/button'
+import Card from 'primevue/card'
 import { componentCatalog } from '@/library/catalog'
 import type { SupportedLocale } from '@/i18n'
 
@@ -29,27 +30,29 @@ const localizedComponents = computed(() =>
       <p class="max-w-2xl text-base text-surface-600 dark:text-surface-300">{{ t('home.description') }}</p>
     </div>
     <div class="grid gap-6 md:grid-cols-2">
-      <article
+      <Card
         v-for="component in localizedComponents"
         :key="component.id"
-        class="card-surface flex flex-col justify-between gap-6 p-6"
       >
-        <div class="space-y-3">
-          <h2 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">{{ component.localizedName }}</h2>
-          <p class="text-sm text-surface-600 dark:text-surface-300">{{ component.localizedDescription }}</p>
-        </div>
-        <RouterLink :to="`/components/${component.id}`" class="self-start">
-          <Button
-            :label="t('home.openPlayground')"
-            icon="pi pi-arrow-right"
-            icon-pos="right"
-            severity="primary"
-            rounded
-            size="small"
-            class="shadow-soft"
-          />
-        </RouterLink>
-      </article>
+        <template #title>
+          {{ component.localizedName }}
+        </template>
+        <template #subtitle>
+          {{ component.localizedDescription }}
+        </template>
+        <template #footer>
+          <RouterLink :to="`/components/${component.id}`">
+            <Button
+              :label="t('home.openPlayground')"
+              icon="pi pi-arrow-right"
+              icon-pos="right"
+              severity="primary"
+              rounded
+              size="small"
+            />
+          </RouterLink>
+        </template>
+      </Card>
     </div>
   </section>
 </template>

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Button from 'primevue/button'
+import Card from 'primevue/card'
+import Divider from 'primevue/divider'
 import type { ComponentDemo } from '@/demos/types'
 import type { ControlDefinition, GroupDefinition, PlaygroundPropValue } from '@/library/types'
 import Field from './field.vue'
@@ -132,38 +135,46 @@ watch(
 </script>
 
 <template>
-  <aside class="card-surface flex h-fit flex-col gap-6 p-6">
-    <div class="flex items-center justify-between">
-      <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary-500">{{ t('playground.controls') }}</p>
-      <button type="button" class="text-xs font-semibold text-primary-500 transition hover:text-primary-400" @click="applyDefaults">
-        {{ t('playground.reset') }}
-      </button>
-    </div>
-    <p class="text-sm text-surface-500 dark:text-surface-400">{{ t('playground.helper') }}</p>
-    <form class="flex flex-col gap-6">
-      <template v-if="hasControls">
-        <div v-for="(section, sectionIndex) in controlSections" :key="section.id" class="flex flex-col gap-4">
-          <Section
-            :section="section"
-          >
-            <Field
-              v-for="control in section.controls"
-              :key="control.key"
-              :control="control"
-              v-model:value="demoProps[control.key]"
-              :is-optional="isControlOptional(control)"
-              @toggle-optional="handleOptionalToggle(control, $event)"
-            />
-          </Section>
-          <hr
-            v-if="section.group && sectionIndex < controlSections.length - 1"
-            class="border-0 border-t border-surface-200/70 dark:border-surface-700/70"
+  <Card>
+    <template #title>
+      {{ t('playground.controls') }}
+    </template>
+    <template #content>
+      <div class="flex flex-col gap-5">
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-surface-600 dark:text-surface-300">{{ t('playground.helper') }}</p>
+          <Button
+            type="button"
+            :label="t('playground.reset')"
+            text
+            @click="applyDefaults"
           />
         </div>
-      </template>
-      <p v-else class="text-sm text-surface-500 dark:text-surface-400">
-        {{ t('playground.noProps') }}
-      </p>
-    </form>
-  </aside>
+        <form class="flex flex-col gap-5">
+          <template v-if="hasControls">
+            <div v-for="(section, sectionIndex) in controlSections" :key="section.id" class="flex flex-col gap-4">
+              <Section
+                :section="section"
+              >
+                <Field
+                  v-for="control in section.controls"
+                  :key="control.key"
+                  :control="control"
+                  v-model:value="demoProps[control.key]"
+                  :is-optional="isControlOptional(control)"
+                  @toggle-optional="handleOptionalToggle(control, $event)"
+                />
+              </Section>
+              <Divider
+                v-if="section.group && sectionIndex < controlSections.length - 1"
+              />
+            </div>
+          </template>
+          <p v-else class="text-sm text-surface-500 dark:text-surface-400">
+            {{ t('playground.noProps') }}
+          </p>
+        </form>
+      </div>
+    </template>
+  </Card>
 </template>

--- a/playground/src/views/core/controls/section.vue
+++ b/playground/src/views/core/controls/section.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Button from 'primevue/button'
 import type { ControlDefinition, GroupDefinition, LocaleCopy } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 
@@ -35,16 +36,17 @@ const handleToggle = () => {
 
 <template>
   <div class="flex flex-col gap-4">
-    <button
+    <Button
       v-if="hasGroup && section.group"
       type="button"
-      class="flex items-center justify-between text-left text-xs font-semibold uppercase tracking-[0.35em] text-surface-500 transition hover:text-primary-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-200 dark:text-surface-400"
+      :label="localize(section.group.label)"
+      :icon="isCollapsed ? 'pi pi-angle-down' : 'pi pi-angle-up'"
+      icon-pos="right"
+      text
+      class="justify-between"
       :aria-expanded="isCollapsed ? 'false' : 'true'"
       @click="handleToggle"
-    >
-      <span>{{ localize(section.group.label) }}</span>
-      <i class="pi text-sm" :class="isCollapsed ? 'pi-angle-down' : 'pi-angle-up'" aria-hidden="true"></i>
-    </button>
+    />
     <div v-show="!hasGroup || !isCollapsed" class="flex flex-col gap-4">
       <slot />
     </div>

--- a/playground/src/views/core/notFound.vue
+++ b/playground/src/views/core/notFound.vue
@@ -1,23 +1,31 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import Button from 'primevue/button'
+import Card from 'primevue/card'
 
 const { t } = useI18n()
 </script>
 
 <template>
-  <div class="card-surface flex flex-col items-center gap-5 p-10 text-center">
-    <div class="text-4xl text-primary-500">
-      <i class="pi pi-compass"></i>
-    </div>
-    <h1 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">{{ t('playground.notFoundTitle') }}</h1>
-    <p class="max-w-md text-sm text-surface-600 dark:text-surface-300">{{ t('playground.notFoundDescription') }}</p>
-    <RouterLink
-      to="/"
-      class="inline-flex items-center gap-2 rounded-full bg-primary-500 px-4 py-2 text-sm font-medium text-primary-contrast shadow-soft transition hover:bg-primary-400"
-    >
-      {{ t('playground.backHome') }}
-      <i class="pi pi-arrow-right text-xs"></i>
-    </RouterLink>
-  </div>
+  <Card>
+    <template #content>
+      <div class="flex flex-col items-center gap-4 text-center">
+        <div class="text-4xl text-primary-500">
+          <i class="pi pi-compass"></i>
+        </div>
+        <h1 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">{{ t('playground.notFoundTitle') }}</h1>
+        <p class="max-w-md text-sm text-surface-600 dark:text-surface-300">{{ t('playground.notFoundDescription') }}</p>
+        <RouterLink to="/">
+          <Button
+            :label="t('playground.backHome')"
+            icon="pi pi-arrow-right"
+            icon-pos="right"
+            severity="primary"
+            rounded
+          />
+        </RouterLink>
+      </div>
+    </template>
+  </Card>
 </template>

--- a/playground/src/views/core/preview.vue
+++ b/playground/src/views/core/preview.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import Card from 'primevue/card'
+import Panel from 'primevue/panel'
 import type { ComponentDemo } from '@/demos/types'
 import type { LabComponentSummary } from '@/library/catalog'
 import type { LocaleCopy, PlaygroundPropValue } from '@/library/types'
@@ -65,14 +67,20 @@ watch(
 </script>
 
 <template>
-  <section class="card-surface flex flex-col gap-6 p-6">
-    <header class="space-y-3">
-      <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary-500">{{ t('playground.preview') }}</p>
-      <h1 class="text-3xl font-semibold text-surface-900 dark:text-surface-0">{{ localizedName }}</h1>
-      <p class="text-sm text-surface-600 dark:text-surface-300">{{ localizedDescription }}</p>
-    </header>
-    <div class="relative min-h-[360px] overflow-hidden rounded-3xl border border-surface-200/70 bg-surface-0 p-6 shadow-inner dark:border-surface-800/70 dark:bg-surface-900">
-      <component :is="demoComponent" v-bind="resolvedDemoProps" />
-    </div>
-  </section>
+  <Card>
+    <template #title>
+      {{ t('playground.preview') }}
+    </template>
+    <template #content>
+      <div class="space-y-4">
+        <div class="space-y-2">
+          <h1 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">{{ localizedName }}</h1>
+          <p class="text-sm text-surface-600 dark:text-surface-300">{{ localizedDescription }}</p>
+        </div>
+        <Panel :pt="{ content: { class: 'min-h-[360px]' } }">
+          <component :is="demoComponent" v-bind="resolvedDemoProps" />
+        </Panel>
+      </div>
+    </template>
+  </Card>
 </template>


### PR DESCRIPTION
## Summary
- replace playground cards with PrimeVue Card and Panel wrappers to respect built-in styling
- refactor controls sidebar, section toggles, and empty state actions to use PrimeVue buttons and dividers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5ff0451f4832c8901cf5c858890bd