### PR TITLE
Fix PrimeVue dark mode selector

### DIFF
--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -18,7 +18,7 @@ app.use(PrimeVue, {
   theme: {
     preset: Aura,
     options: {
-      darkModeSelector: 'class',
+      darkModeSelector: '.dark',
     },
   },
 })


### PR DESCRIPTION
## Summary
- configure the PrimeVue theme to use the `.dark` class so dark mode tokens apply to components like Card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e605b93dcc832c9421e3b73ef25e42