### PR TITLE
Refactor playground text elements to use Element Plus Text

### DIFF
--- a/playground/src/demos/BlurOverlayDemo.vue
+++ b/playground/src/demos/BlurOverlayDemo.vue
@@ -33,6 +33,7 @@ export const demoConfig: ComponentDemoConfig = {
 </script>
 
 <script setup lang="ts">
+import { ElText } from 'element-plus'
 import { BlurOverlay, type BlurOverlayProps } from '@library/components'
 
 defineProps<BlurOverlayProps>()
@@ -47,13 +48,20 @@ defineProps<BlurOverlayProps>()
     />
     <BlurOverlay v-bind="$props">
       <div class="flex flex-col gap-4">
-        <span class="text-xs font-semibold uppercase tracking-[0.4em] text-primary-500">
+        <ElText
+          tag="span"
+          class="font-semibold uppercase tracking-[0.4em]"
+          size="small"
+          type="primary"
+        >
           Focus Mode
-        </span>
-        <h2 class="text-2xl font-semibold">Shipping polished experiences</h2>
-        <p class="text-sm">
+        </ElText>
+        <ElText tag="h2" class="text-2xl font-semibold">
+          Shipping polished experiences
+        </ElText>
+        <ElText tag="p" size="small">
           Blur surrounding distractions while presenting a focused call-to-action for your customers.
-        </p>
+        </ElText>
       </div>
     </BlurOverlay>
   </div>

--- a/playground/src/views/HomePage.vue
+++ b/playground/src/views/HomePage.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { ElText } from 'element-plus'
 import Button from 'primevue/button'
 import Card from 'primevue/card'
 import { componentCatalog } from '@/library/catalog'
@@ -25,9 +26,20 @@ const localizedComponents = computed(() =>
 <template>
   <section class="space-y-4">
     <div class="space-y-3">
-      <p class="text-sm font-semibold uppercase tracking-[0.4em] text-primary-500">Component Lab</p>
-      <h1 class="text-4xl font-semibold text-surface-900 dark:text-surface-0">{{ t('home.title') }}</h1>
-      <p class="max-w-2xl text-base text-surface-600 dark:text-surface-300">{{ t('home.description') }}</p>
+      <ElText
+        tag="p"
+        class="font-semibold uppercase tracking-[0.4em]"
+        size="small"
+        type="primary"
+      >
+        Component Lab
+      </ElText>
+      <ElText tag="h1" class="text-4xl font-semibold">
+        {{ t('home.title') }}
+      </ElText>
+      <ElText tag="p" class="max-w-2xl" type="info">
+        {{ t('home.description') }}
+      </ElText>
     </div>
     <div class="grid gap-6 md:grid-cols-2">
       <Card

--- a/playground/src/views/core/controls/field.vue
+++ b/playground/src/views/core/controls/field.vue
@@ -6,7 +6,7 @@ import Dropdown from 'primevue/dropdown'
 import InputText from 'primevue/inputtext'
 import Slider from 'primevue/slider'
 import Textarea from 'primevue/textarea'
-import { ElColorPicker } from 'element-plus'
+import { ElColorPicker, ElText } from 'element-plus'
 import type { ControlDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 import { toRgba } from '@shared/color'
@@ -148,7 +148,14 @@ const booleanModel = computed<boolean | undefined>({
           :aria-labelledby="isOptional ? labelId : undefined"
           class="flex-1"
         />
-        <span class="w-12 text-right text-xs font-semibold text-primary-500">{{ numberModel ?? '' }}</span>
+        <ElText
+          tag="span"
+          class="inline-block w-12 text-right font-semibold"
+          size="small"
+          type="primary"
+        >
+          {{ numberModel ?? '' }}
+        </ElText>
       </div>
     </template>
     <template v-else-if="control.type === 'boolean'">
@@ -159,8 +166,13 @@ const booleanModel = computed<boolean | undefined>({
         </label>
       </div>
     </template>
-    <p v-if="control.helperText && isActive" class="text-xs text-surface-500 dark:text-surface-400">
+    <ElText
+      v-if="control.helperText && isActive"
+      tag="p"
+      size="small"
+      type="info"
+    >
       {{ localize(control.helperText) }}
-    </p>
+    </ElText>
   </div>
 </template>

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { ElText } from 'element-plus'
 import Button from 'primevue/button'
 import Card from 'primevue/card'
 import Divider from 'primevue/divider'
@@ -142,7 +143,9 @@ watch(
     <template #content>
       <div class="flex flex-col gap-5">
         <div class="flex items-center justify-between">
-          <p class="text-sm text-surface-600 dark:text-surface-300">{{ t('playground.helper') }}</p>
+          <ElText tag="p" size="small" type="info">
+            {{ t('playground.helper') }}
+          </ElText>
           <Button
             type="button"
             :label="t('playground.reset')"
@@ -170,9 +173,9 @@ watch(
               />
             </div>
           </template>
-          <p v-else class="text-sm text-surface-500 dark:text-surface-400">
+          <ElText v-else tag="p" size="small" type="info">
             {{ t('playground.noProps') }}
-          </p>
+          </ElText>
         </form>
       </div>
     </template>

--- a/playground/src/views/core/notFound.vue
+++ b/playground/src/views/core/notFound.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { ElText } from 'element-plus'
 import Button from 'primevue/button'
 import Card from 'primevue/card'
 
@@ -14,8 +15,12 @@ const { t } = useI18n()
         <div class="text-4xl text-primary-500">
           <i class="pi pi-compass"></i>
         </div>
-        <h1 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">{{ t('playground.notFoundTitle') }}</h1>
-        <p class="max-w-md text-sm text-surface-600 dark:text-surface-300">{{ t('playground.notFoundDescription') }}</p>
+        <ElText tag="h1" class="text-2xl font-semibold">
+          {{ t('playground.notFoundTitle') }}
+        </ElText>
+        <ElText tag="p" class="max-w-md" size="small" type="info">
+          {{ t('playground.notFoundDescription') }}
+        </ElText>
         <RouterLink to="/">
           <Button
             :label="t('playground.backHome')"

--- a/playground/src/views/core/preview.vue
+++ b/playground/src/views/core/preview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { ElText } from 'element-plus'
 import Card from 'primevue/card'
 import Panel from 'primevue/panel'
 import type { ComponentDemo } from '@/demos/types'
@@ -74,8 +75,12 @@ watch(
     <template #content>
       <div class="space-y-4">
         <div class="space-y-2">
-          <h1 class="text-2xl font-semibold text-surface-900 dark:text-surface-0">{{ localizedName }}</h1>
-          <p class="text-sm text-surface-600 dark:text-surface-300">{{ localizedDescription }}</p>
+          <ElText tag="h1" class="text-2xl font-semibold">
+            {{ localizedName }}
+          </ElText>
+          <ElText tag="p" size="small" type="info">
+            {{ localizedDescription }}
+          </ElText>
         </div>
         <Panel :pt="{ content: { class: 'min-h-[360px]' } }">
           <component :is="demoComponent" v-bind="resolvedDemoProps" />


### PR DESCRIPTION
## Summary
- replace playground text elements and headings with Element Plus `ElText` to unify styling across demos and views
- simplify heading text classes to rely on the global surface color tokens instead of duplicating dark and light variants

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6081bcf50832c938bc23835e52cd9