### PR TITLE
Refactor App shell to use PrimeVue components

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -2,6 +2,10 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { RouterLink, RouterView, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { ElText } from 'element-plus'
+import Toolbar from 'primevue/toolbar'
+import Button from 'primevue/button'
+import SelectButton from 'primevue/selectbutton'
 import { localeStorageKey } from '@/i18n'
 
 type ThemeVariant = 'light' | 'dark'
@@ -11,10 +15,15 @@ const themeStorageKey = 'component-lab-theme'
 const { locale, t } = useI18n()
 const route = useRoute()
 
-const languageOptions = [
+type LanguageOption = {
+  value: 'en' | 'ko'
+  label: string
+}
+
+const languageOptions: LanguageOption[] = [
   { value: 'en', label: 'EN' },
   { value: 'ko', label: '한국어' },
-] as const
+]
 
 const resolveInitialTheme = (): ThemeVariant => {
   if (typeof window === 'undefined') {
@@ -45,13 +54,20 @@ const toggleTheme = () => {
   theme.value = theme.value === 'dark' ? 'light' : 'dark'
 }
 
-const setLocale = (value: (typeof languageOptions)[number]['value']) => {
+const setLocale = (value: LanguageOption['value']) => {
   if (locale.value !== value) {
     locale.value = value
   }
 }
 
 const themeIcon = computed(() => (theme.value === 'dark' ? 'pi pi-sun' : 'pi pi-moon'))
+
+const selectedLocale = computed({
+  get: () => locale.value,
+  set: (value) => {
+    setLocale(value as LanguageOption['value'])
+  },
+})
 
 onMounted(() => {
   applyTheme(theme.value)
@@ -91,47 +107,54 @@ watch(
 </script>
 
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-surface-50 via-surface-0 to-primary-50/30 text-surface-800 transition-colors dark:from-surface-950 dark:via-surface-950 dark:to-surface-900 dark:text-surface-0">
-    <header class="sticky top-0 z-40 border-b border-surface-200/70 bg-surface-0/70 backdrop-blur dark:border-surface-800/70 dark:bg-surface-950/70">
-      <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-5">
-        <RouterLink to="/" class="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
-          <span class="text-xl font-semibold tracking-tight text-surface-900 dark:text-surface-0">{{ t('app.title') }}</span>
+  <div class="app-container">
+    <Toolbar>
+      <template #start>
+        <RouterLink to="/">
+          <ElText tag="h1" size="large">{{ t('app.title') }}</ElText>
         </RouterLink>
-        <div class="flex items-center gap-3">
-          <nav
-            aria-label="Language switcher"
-            class="flex rounded-full border border-surface-200/70 bg-surface-0/80 p-1 shadow-sm backdrop-blur dark:border-surface-700/70 dark:bg-surface-800/80"
-          >
-            <button
-              v-for="option in languageOptions"
-              :key="option.value"
-              type="button"
-              class="rounded-full px-3 py-1.5 text-sm font-medium transition-colors"
-              :class="
-                locale === option.value
-                  ? 'bg-primary-500 text-primary-contrast shadow-sm'
-                  : 'text-surface-600 dark:text-surface-300 hover:text-primary-500'
-              "
-              @click="setLocale(option.value)"
-            >
-              {{ option.label }}
-            </button>
-          </nav>
-          <button
-            type="button"
-            class="flex h-10 w-10 items-center justify-center rounded-full border border-surface-200/70 bg-surface-0/90 text-surface-600 shadow-sm transition-colors hover:text-primary-500 dark:border-surface-700/70 dark:bg-surface-800/80 dark:text-surface-300"
-            :title="t('app.themeToggle')"
-            @click="toggleTheme"
-          >
-            <i :class="themeIcon" class="text-lg"></i>
-            <span class="sr-only">{{ t('app.themeToggle') }}</span>
-          </button>
-        </div>
-      </div>
-    </header>
-
-    <main class="mx-auto w-full max-w-6xl px-6 pb-16 pt-10">
+      </template>
+      <template #end>
+        <SelectButton
+          v-model="selectedLocale"
+          :options="languageOptions"
+          optionLabel="label"
+          optionValue="value"
+          :allowEmpty="false"
+        />
+        <Button
+          type="button"
+          :icon="themeIcon"
+          rounded
+          text
+          :aria-label="t('app.themeToggle')"
+          :title="t('app.themeToggle')"
+          @click="toggleTheme"
+        />
+      </template>
+    </Toolbar>
+    <main class="main-content">
       <RouterView :key="route.fullPath" />
     </main>
   </div>
 </template>
+
+<style scoped>
+.app-container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
+}
+
+.main-content {
+  padding: 1.5rem;
+}
+
+:deep(a) {
+  text-decoration: none;
+}
+</style>

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -107,7 +107,7 @@ watch(
 </script>
 
 <template>
-  <div class="app-container">
+  <div class="flex flex-col  min-h-screen">
     <Toolbar>
       <template #start>
         <RouterLink to="/">
@@ -133,28 +133,8 @@ watch(
         />
       </template>
     </Toolbar>
-    <main class="main-content">
+    <main class="flex px-6 pb-16">
       <RouterView :key="route.fullPath" />
     </main>
   </div>
 </template>
-
-<style scoped>
-.app-container {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
-main {
-  flex: 1;
-}
-
-.main-content {
-  padding: 1.5rem;
-}
-
-:deep(a) {
-  text-decoration: none;
-}
-</style>


### PR DESCRIPTION
## Summary
- replace the custom header shell with PrimeVue Toolbar, SelectButton, and Button components
- switch the title rendering to Element Plus ElText and simplify the surrounding layout styles
- preserve locale and theme toggling behaviors through computed bindings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e613f3861c832ca7f37c2e2efb2126