### PR TITLE
Refactor App layout to use PrimeVue components

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -2,6 +2,10 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { RouterLink, RouterView, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import Button from 'primevue/button'
+import SelectButton from 'primevue/selectbutton'
+import Toolbar from 'primevue/toolbar'
+import { ElText } from 'element-plus'
 import { localeStorageKey } from '@/i18n'
 
 type ThemeVariant = 'light' | 'dark'
@@ -14,7 +18,9 @@ const route = useRoute()
 const languageOptions = [
   { value: 'en', label: 'EN' },
   { value: 'ko', label: '한국어' },
-] as const
+]
+
+type LanguageValue = (typeof languageOptions)[number]['value']
 
 const resolveInitialTheme = (): ThemeVariant => {
   if (typeof window === 'undefined') {
@@ -45,11 +51,14 @@ const toggleTheme = () => {
   theme.value = theme.value === 'dark' ? 'light' : 'dark'
 }
 
-const setLocale = (value: (typeof languageOptions)[number]['value']) => {
-  if (locale.value !== value) {
-    locale.value = value
-  }
-}
+const selectedLocale = computed({
+  get: () => locale.value,
+  set: (value: LanguageValue) => {
+    if (value && locale.value !== value) {
+      locale.value = value
+    }
+  },
+})
 
 const themeIcon = computed(() => (theme.value === 'dark' ? 'pi pi-sun' : 'pi pi-moon'))
 
@@ -91,43 +100,34 @@ watch(
 </script>
 
 <template>
-  <div class="min-h-screen bg-gradient-to-br from-surface-50 via-surface-0 to-primary-50/30 text-surface-800 transition-colors dark:from-surface-950 dark:via-surface-950 dark:to-surface-900 dark:text-surface-0">
-    <header class="sticky top-0 z-40 border-b border-surface-200/70 bg-surface-0/70 backdrop-blur dark:border-surface-800/70 dark:bg-surface-950/70">
-      <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-5">
-        <RouterLink to="/" class="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
-          <span class="text-xl font-semibold tracking-tight text-surface-900 dark:text-surface-0">{{ t('app.title') }}</span>
-        </RouterLink>
-        <div class="flex items-center gap-3">
-          <nav
-            aria-label="Language switcher"
-            class="flex rounded-full border border-surface-200/70 bg-surface-0/80 p-1 shadow-sm backdrop-blur dark:border-surface-700/70 dark:bg-surface-800/80"
-          >
-            <button
-              v-for="option in languageOptions"
-              :key="option.value"
-              type="button"
-              class="rounded-full px-3 py-1.5 text-sm font-medium transition-colors"
-              :class="
-                locale === option.value
-                  ? 'bg-primary-500 text-primary-contrast shadow-sm'
-                  : 'text-surface-600 dark:text-surface-300 hover:text-primary-500'
-              "
-              @click="setLocale(option.value)"
-            >
-              {{ option.label }}
-            </button>
-          </nav>
-          <button
-            type="button"
-            class="flex h-10 w-10 items-center justify-center rounded-full border border-surface-200/70 bg-surface-0/90 text-surface-600 shadow-sm transition-colors hover:text-primary-500 dark:border-surface-700/70 dark:bg-surface-800/80 dark:text-surface-300"
-            :title="t('app.themeToggle')"
-            @click="toggleTheme"
-          >
-            <i :class="themeIcon" class="text-lg"></i>
-            <span class="sr-only">{{ t('app.themeToggle') }}</span>
-          </button>
-        </div>
-      </div>
+  <div class="min-h-screen">
+    <header class="sticky top-0 z-40">
+      <Toolbar>
+        <template #start>
+          <RouterLink to="/">
+            <ElText size="large" tag="span">{{ t('app.title') }}</ElText>
+          </RouterLink>
+        </template>
+        <template #end>
+          <div class="flex items-center gap-2">
+            <SelectButton
+              v-model="selectedLocale"
+              :options="languageOptions"
+              optionLabel="label"
+              optionValue="value"
+              :allowEmpty="false"
+              aria-label="Language switcher"
+            />
+            <Button
+              :icon="themeIcon"
+              @click="toggleTheme"
+              rounded
+              severity="secondary"
+              :aria-label="t('app.themeToggle')"
+            />
+          </div>
+        </template>
+      </Toolbar>
     </header>
 
     <main class="mx-auto w-full max-w-6xl px-6 pb-16 pt-10">


### PR DESCRIPTION
## Summary
- replace manual header elements with PrimeVue Toolbar, SelectButton, and Button components
- switch the application title rendering to Element Plus ElText and bind locale changes through a computed helper
- simplify the surrounding structure so PrimeVue component styling is used by default

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e617c44ba4832cbea15300c329e17a