### PR TITLE
Adjust reset button text size

### DIFF
--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -149,6 +149,7 @@ watch(
           <Button
             type="button"
             :label="t('playground.reset')"
+            class="text-xs"
             text
             @click="applyDefaults"
           />


### PR DESCRIPTION
## Summary
- reduce the reset button text size in the playground controls view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e61cc64a30832c8fcfc64a811859bf