### PR TITLE
refactor: switch playground field inputs to element plus

### DIFF
--- a/playground/src/views/core/controls/field.vue
+++ b/playground/src/views/core/controls/field.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import Checkbox from 'primevue/checkbox'
-import Dropdown from 'primevue/dropdown'
-import InputText from 'primevue/inputtext'
-import Slider from 'primevue/slider'
-import Textarea from 'primevue/textarea'
-import { ElColorPicker, ElText } from 'element-plus'
+import {
+  ElCheckbox,
+  ElColorPicker,
+  ElInput,
+  ElOption,
+  ElSelect,
+  ElSlider,
+  ElText,
+} from 'element-plus'
 import type { ControlDefinition, LocaleCopy, PlaygroundPropValue } from '@/library/types'
 import type { SupportedLocale } from '@/i18n'
 import { toRgba } from '@shared/color'
@@ -70,10 +73,9 @@ const booleanModel = computed<boolean | undefined>({
 <template>
   <div class="flex flex-col gap-2 text-sm">
     <div v-if="isOptional" class="flex items-center gap-2">
-      <Checkbox
-        :input-id="toggleId"
+      <ElCheckbox
+        :id="toggleId"
         :model-value="isActive"
-        binary
         class="shrink-0"
         :aria-controls="inputId"
         :aria-expanded="isActive ? 'true' : 'false'"
@@ -89,7 +91,7 @@ const booleanModel = computed<boolean | undefined>({
       {{ localize(control.label) }}
     </label>
     <template v-if="control.type === 'text'">
-      <InputText
+      <ElInput
         v-if="isActive"
         :id="inputId"
         v-model="stringModel"
@@ -98,27 +100,32 @@ const booleanModel = computed<boolean | undefined>({
       />
     </template>
     <template v-else-if="control.type === 'textarea'">
-      <Textarea
+      <ElInput
         v-if="isActive"
         :id="inputId"
         v-model="stringModel"
+        type="textarea"
         rows="4"
-        auto-resize
+        :autosize="true"
         :aria-labelledby="isOptional ? labelId : undefined"
         class="w-full"
       />
     </template>
     <template v-else-if="control.type === 'select'">
-      <Dropdown
+      <ElSelect
         v-if="isActive"
         :id="inputId"
         v-model="valueModel"
-        :options="selectOptions"
-        option-label="label"
-        option-value="value"
         :aria-labelledby="isOptional ? labelId : undefined"
         class="w-full"
-      />
+      >
+        <ElOption
+          v-for="option in selectOptions"
+          :key="option.value"
+          :label="option.label"
+          :value="option.value"
+        />
+      </ElSelect>
     </template>
     <template v-else-if="control.type === 'color'">
       <div v-if="isActive" class="flex items-center gap-3">
@@ -129,7 +136,7 @@ const booleanModel = computed<boolean | undefined>({
           class="shrink-0"
           :aria-labelledby="isOptional ? labelId : undefined"
         />
-        <InputText
+        <ElInput
           :id="inputId"
           v-model="stringModel"
           :aria-labelledby="isOptional ? labelId : undefined"
@@ -139,7 +146,7 @@ const booleanModel = computed<boolean | undefined>({
     </template>
     <template v-else-if="control.type === 'slider'">
       <div v-if="isActive" class="flex items-center gap-3">
-        <Slider
+        <ElSlider
           :id="inputId"
           v-model="numberModel"
           :min="control.min ?? 0"
@@ -160,7 +167,7 @@ const booleanModel = computed<boolean | undefined>({
     </template>
     <template v-else-if="control.type === 'boolean'">
       <div v-if="isActive" class="inline-flex items-center gap-3">
-        <Checkbox :input-id="inputId" v-model="booleanModel" binary />
+        <ElCheckbox :id="inputId" v-model="booleanModel" />
         <label :for="inputId" class="text-sm text-surface-600 dark:text-surface-300">
           {{ localize(control.label) }}
         </label>


### PR DESCRIPTION
## Summary
- replace the PrimeVue field controls with Element Plus components to match the rest of the UI stack
- update select rendering to rely on `ElSelect` and `ElOption` while keeping existing model bindings intact

## Testing
- npm run build *(fails: npm not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e61bf00480832ca3b88328efd8e4cf