### PR TITLE
Enable concurrency cancellation for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: component-lab-pages
-  cancel-in-progress: false
+  group: component-lab-pages-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- scope the deploy workflow concurrency group per ref and cancel in-progress runs so only the newest job executes

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e624b21a84832c9a6cb13f899e8eeb