### PR TITLE
Use Element Plus link for control reset button

### DIFF
--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -141,19 +141,17 @@ watch(
     </template>
     <template #content>
       <div class="flex flex-col gap-5">
-        <div class="flex items-center justify-between">
-          <ElText tag="p" size="small" type="info">
-            {{ t('playground.helper') }}
-          </ElText>
-          <ElLink
-            type="primary"
-            :underline="false"
-            class="text-xs"
-            @click="applyDefaults"
-          >
-            {{ t('playground.reset') }}
-          </ElLink>
-        </div>
+        <ElText tag="p" size="small" type="info">
+          {{ t('playground.helper') }}
+        </ElText>
+        <ElLink
+          type="primary"
+          :underline="false"
+          class="text-xs"
+          @click="applyDefaults"
+        >
+          {{ t('playground.reset') }}
+        </ElLink>
         <form class="flex flex-col gap-5">
           <template v-if="hasControls">
             <div v-for="(section, sectionIndex) in controlSections" :key="section.id" class="flex flex-col gap-4">

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { ElText } from 'element-plus'
-import Button from 'primevue/button'
+import { ElLink, ElText } from 'element-plus'
 import Card from 'primevue/card'
 import Divider from 'primevue/divider'
 import type { ComponentDemo } from '@/demos/types'
@@ -146,13 +145,14 @@ watch(
           <ElText tag="p" size="small" type="info">
             {{ t('playground.helper') }}
           </ElText>
-          <Button
-            type="button"
-            :label="t('playground.reset')"
+          <ElLink
+            type="primary"
+            :underline="false"
             class="text-xs"
-            text
             @click="applyDefaults"
-          />
+          >
+            {{ t('playground.reset') }}
+          </ElLink>
         </div>
         <form class="flex flex-col gap-5">
           <template v-if="hasControls">


### PR DESCRIPTION
## Summary
- replace the controls panel reset button to use the Element Plus link component
- keep the reset handler intact so defaults are still applied

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e627a28ae0832cb5af9ffb5a45f239