### PR TITLE
feat: refine toolbar transparency via pass-through

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -103,11 +103,11 @@ watch(
   <div class="min-h-screen">
     <header class="sticky top-0 z-40 px-4 pt-4">
       <Toolbar
-        class="mx-auto max-w-6xl rounded-full shadow-lg backdrop-blur"
         :pt="{
           root: {
-            class: 'border-none',
+            class: 'mx-auto max-w-6xl rounded-full shadow-lg backdrop-blur',
             style: {
+              border: 'none',
               background: 'color-mix(in srgb, var(--p-toolbar-background, #ffffff) 75%, transparent)'
             }
           }

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -102,7 +102,17 @@ watch(
 <template>
   <div class="min-h-screen">
     <header class="sticky top-0 z-40 px-4 pt-4">
-      <Toolbar class="mx-auto max-w-6xl rounded-full shadow-lg backdrop-blur" pt="{ class: 'border-none bg-white/75 dark:bg-slate-900/75' }">
+      <Toolbar
+        class="mx-auto max-w-6xl rounded-full shadow-lg backdrop-blur"
+        :pt="{
+          root: {
+            class: 'border-none',
+            style: {
+              background: 'color-mix(in srgb, var(--p-toolbar-background, #ffffff) 75%, transparent)'
+            }
+          }
+        }"
+      >
         <template #start>
           <RouterLink to="/">
             <ElText tag="b" size="large">{{ t('app.title') }}</ElText>


### PR DESCRIPTION
## Summary
- remove the toolbar border via PrimeVue pass-through styling
- apply a 75% transparent background that reuses the toolbar design token color

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e628f3a944832ca3853426475bb3dd