### PR TITLE
Adjust control panel reset link alignment

### DIFF
--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -141,17 +141,19 @@ watch(
     </template>
     <template #content>
       <div class="flex flex-col gap-5">
-        <ElText tag="p" size="small" type="info">
-          {{ t('playground.helper') }}
-        </ElText>
-        <ElLink
-          type="primary"
-          :underline="false"
-          class="text-xs"
-          @click="applyDefaults"
-        >
-          {{ t('playground.reset') }}
-        </ElLink>
+        <div class="flex flex-col gap-2">
+          <ElText tag="p" size="small" type="info">
+            {{ t('playground.helper') }}
+          </ElText>
+          <ElLink
+            type="primary"
+            :underline="false"
+            class="self-end w-fit text-xs"
+            @click="applyDefaults"
+          >
+            {{ t('playground.reset') }}
+          </ElLink>
+        </div>
         <form class="flex flex-col gap-5">
           <template v-if="hasControls">
             <div v-for="(section, sectionIndex) in controlSections" :key="section.id" class="flex flex-col gap-4">


### PR DESCRIPTION
## Summary
- align the control panel reset link to the right and constrain its clickable area to the link text
- group the helper message and reset action with tighter spacing for consistency

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e62e6898e8832cbbaae36a3a72d4d9