### PR TITLE
Remove divider from controls view

### DIFF
--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -153,22 +153,23 @@ watch(
             {{ t('playground.reset') }}
           </ElLink>
         </div>
-        <form class="flex flex-col gap-5">
+        <form class="flex flex-col">
           <template v-if="hasControls">
-            <div v-for="(section, sectionIndex) in controlSections" :key="section.id" class="flex flex-col gap-4">
-              <Section
-                :section="section"
-              >
-                <Field
-                  v-for="control in section.controls"
-                  :key="control.key"
-                  :control="control"
-                  v-model:value="demoProps[control.key]"
-                  :is-optional="isControlOptional(control)"
-                  @toggle-optional="handleOptionalToggle(control, $event)"
-                />
-              </Section>
-            </div>
+            <Section
+              v-for="section in controlSections"
+              :key="section.id"
+              :section="section"
+              :class="['first:mt-0', section.group ? 'mt-0' : 'mt-5']"
+            >
+              <Field
+                v-for="control in section.controls"
+                :key="control.key"
+                :control="control"
+                v-model:value="demoProps[control.key]"
+                :is-optional="isControlOptional(control)"
+                @toggle-optional="handleOptionalToggle(control, $event)"
+              />
+            </Section>
           </template>
           <ElText v-else tag="p" size="small" type="info">
             {{ t('playground.noProps') }}

--- a/playground/src/views/core/controls/index.vue
+++ b/playground/src/views/core/controls/index.vue
@@ -3,7 +3,6 @@ import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ElLink, ElText } from 'element-plus'
 import Card from 'primevue/card'
-import Divider from 'primevue/divider'
 import type { ComponentDemo } from '@/demos/types'
 import type { ControlDefinition, GroupDefinition, PlaygroundPropValue } from '@/library/types'
 import Field from './field.vue'
@@ -169,9 +168,6 @@ watch(
                   @toggle-optional="handleOptionalToggle(control, $event)"
                 />
               </Section>
-              <Divider
-                v-if="section.group && sectionIndex < controlSections.length - 1"
-              />
             </div>
           </template>
           <ElText v-else tag="p" size="small" type="info">


### PR DESCRIPTION
## Summary
- remove the unused PrimeVue divider import from the playground controls view
- eliminate the divider element between control sections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e632f3c1a4832c8addfdd58bea2db7