### PR TITLE
Use radio buttons for boolean controls

### DIFF
--- a/playground/src/i18n/index.ts
+++ b/playground/src/i18n/index.ts
@@ -23,8 +23,6 @@ const messages = {
       notFoundDescription: 'The component you are looking for does not exist or is not yet available.',
       backHome: 'Back to home',
       toggleControl: 'Toggle editing for “{name}”',
-      booleanTrue: 'True',
-      booleanFalse: 'False',
     },
   },
   ko: {
@@ -47,8 +45,6 @@ const messages = {
       notFoundDescription: '요청한 컴포넌트가 존재하지 않거나 아직 준비되지 않았습니다.',
       backHome: '홈으로 돌아가기',
       toggleControl: '“{name}” 수정 전환',
-      booleanTrue: '참',
-      booleanFalse: '거짓',
     },
   },
 }

--- a/playground/src/i18n/index.ts
+++ b/playground/src/i18n/index.ts
@@ -23,6 +23,8 @@ const messages = {
       notFoundDescription: 'The component you are looking for does not exist or is not yet available.',
       backHome: 'Back to home',
       toggleControl: 'Toggle editing for “{name}”',
+      booleanTrue: 'True',
+      booleanFalse: 'False',
     },
   },
   ko: {
@@ -45,6 +47,8 @@ const messages = {
       notFoundDescription: '요청한 컴포넌트가 존재하지 않거나 아직 준비되지 않았습니다.',
       backHome: '홈으로 돌아가기',
       toggleControl: '“{name}” 수정 전환',
+      booleanTrue: '참',
+      booleanFalse: '거짓',
     },
   },
 }

--- a/playground/src/views/core/controls/field.vue
+++ b/playground/src/views/core/controls/field.vue
@@ -148,33 +148,28 @@ const booleanModel = computed<boolean | undefined>({
       </div>
     </template>
     <template v-else-if="control.type === 'slider'">
-      <div v-if="isActive" class="flex items-center gap-3">
-        <ElSlider
-          :id="inputId"
-          v-model="numberModel"
-          :min="control.min ?? 0"
-          :max="control.max ?? 100"
-          :step="control.step ?? 1"
-          :aria-label="isOptional ? localize(control.label) : undefined"
-          class="flex-1"
-        />
-      </div>
+      <ElSlider
+        v-if="isActive"
+        :id="inputId"
+        v-model="numberModel"
+        :min="control.min ?? 0"
+        :max="control.max ?? 100"
+        :step="control.step ?? 1"
+        :aria-label="isOptional ? localize(control.label) : undefined"
+        class="flex-1"
+      />
     </template>
     <template v-else-if="control.type === 'boolean'">
-      <div v-if="isActive" class="flex flex-col gap-2">
-        <span class="font-medium text-surface-700 dark:text-surface-200">
-          {{ localize(control.label) }}
-        </span>
-        <ElRadioGroup
-          :id="inputId"
-          v-model="booleanModel"
-          class="flex gap-4"
-          :aria-label="isOptional ? localize(control.label) : undefined"
-        >
-          <ElRadio :label="true">{{ t('playground.booleanTrue') }}</ElRadio>
-          <ElRadio :label="false">{{ t('playground.booleanFalse') }}</ElRadio>
-        </ElRadioGroup>
-      </div>
+      <ElRadioGroup
+        v-if="isActive"
+        :id="inputId"
+        v-model="booleanModel"
+        class="flex gap-4"
+        :aria-label="isOptional ? localize(control.label) : undefined"
+      >
+        <ElRadio :label="true">true</ElRadio>
+        <ElRadio :label="false">false</ElRadio>
+      </ElRadioGroup>
     </template>
     <ElText
       v-if="control.helperText && isActive"

--- a/playground/src/views/core/controls/field.vue
+++ b/playground/src/views/core/controls/field.vue
@@ -6,6 +6,8 @@ import {
   ElColorPicker,
   ElInput,
   ElOption,
+  ElRadio,
+  ElRadioGroup,
   ElSelect,
   ElSlider,
   ElText,
@@ -159,8 +161,19 @@ const booleanModel = computed<boolean | undefined>({
       </div>
     </template>
     <template v-else-if="control.type === 'boolean'">
-      <div v-if="isActive" class="inline-flex items-center gap-3">
-        <ElCheckbox :id="inputId" v-model="booleanModel" :label="localize(control.label)" />
+      <div v-if="isActive" class="flex flex-col gap-2">
+        <span class="font-medium text-surface-700 dark:text-surface-200">
+          {{ localize(control.label) }}
+        </span>
+        <ElRadioGroup
+          :id="inputId"
+          v-model="booleanModel"
+          class="flex gap-4"
+          :aria-label="isOptional ? localize(control.label) : undefined"
+        >
+          <ElRadio :label="true">{{ t('playground.booleanTrue') }}</ElRadio>
+          <ElRadio :label="false">{{ t('playground.booleanFalse') }}</ElRadio>
+        </ElRadioGroup>
       </div>
     </template>
     <ElText


### PR DESCRIPTION
## Summary
- replace boolean control checkboxes with Element Plus radio buttons so users can pick true or false explicitly
- add English and Korean i18n strings for the new true/false radio labels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e63503fc14832c82d5351bcd0c146d