### PR TITLE
Disable CSS tree shaking to expose full playground styles

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,9 @@ export default {
     './playground/src/**/*.{vue,js,ts,jsx,tsx}',
     './library/**/*.{vue,js,ts,jsx,tsx}',
   ],
+  // Tailwind JIT normally tree-shakes unused utilities. Keep everything available
+  // so the playground can experiment with any class without rebuilding.
+  safelist: [{ pattern: /.*/ }],
   darkMode: 'class',
   theme: {
     extend: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,5 +20,10 @@ export default defineConfig({
   build: {
     outDir: path.resolve(__dirname, 'dist'),
     emptyOutDir: true,
+    cssCodeSplit: false,
+    rollupOptions: {
+      // Keep vendor style bundles intact so framework CSS isn't tree-shaken away.
+      treeshake: false,
+    },
   },
 })


### PR DESCRIPTION
## Summary
- safelist all Tailwind utilities so playground pages can use any class without purge
- disable CSS tree shaking in the Vite build to retain PrimeVue and Element Plus styles during compilation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e65bba9714832cb68b81335d224e24