### PR TITLE
Replace shadow-soft classes with shadow-md

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -35,7 +35,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <Group class="grid w-full grid-cols-1 rounded-md shadow-soft transition-colors sm:grid-cols-[minmax(0,1fr)_auto]">
+  <Group class="grid w-full grid-cols-1 rounded-md shadow-md transition-colors sm:grid-cols-[minmax(0,1fr)_auto]">
     <Card class="h-full">
       <template #content>
         <div class="flex h-full flex-col justify-center gap-4" :class="cardClass">

--- a/playground/src/demos/GroupDemo.vue
+++ b/playground/src/demos/GroupDemo.vue
@@ -53,7 +53,7 @@ const calendarPT = {
   <div class="flex justify-center">
     <Group
       v-bind="props"
-      class="group-demo inline-flex w-full max-w-4xl divide-x text-sm shadow-soft"
+      class="group-demo inline-flex w-full max-w-4xl divide-x text-sm shadow-md"
       role="group"
       aria-label="항공권 검색 필터"
     >


### PR DESCRIPTION
## Summary
- update ActionableCard layout to use the standard `shadow-md` utility
- align Group demo styling with the same `shadow-md` shadow level

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e65f33e5a0832ca4a9c58df75110a9