### PR TITLE
Refactor ActionableCard bindings

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -2,16 +2,16 @@
 import Button from 'primevue/button'
 import Card from 'primevue/card'
 import Group from './Group.vue'
-import { defineComponent } from 'vue'
+import { defineComponent, type PropType } from 'vue'
 
 export const defaultProps = {
-  cardClass: undefined,
-  actionClass: undefined,
+  card: () => ({} as Record<string, unknown>),
+  button: () => ({} as Record<string, unknown>),
 } as const
 
 export type props = {
-  cardClass?: string
-  actionClass?: string
+  card?: Record<string, unknown>
+  button?: Record<string, unknown>
 }
 
 export default defineComponent({
@@ -22,13 +22,13 @@ export default defineComponent({
     Group,
   },
   props: {
-    cardClass: {
-      type: String,
-      default: defaultProps.cardClass,
+    card: {
+      type: Object as PropType<Record<string, unknown>>,
+      default: defaultProps.card,
     },
-    actionClass: {
-      type: String,
-      default: defaultProps.actionClass,
+    button: {
+      type: Object as PropType<Record<string, unknown>>,
+      default: defaultProps.button,
     },
   },
 })
@@ -36,14 +36,14 @@ export default defineComponent({
 
 <template>
   <Group class="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto]">
-    <Card class="h-full">
+    <Card class="h-full" v-bind="card">
       <template v-for="(_, name) in $slots" :key="name" v-slot:[name]="data">
         <slot :name="name" v-bind="data" />
       </template>
     </Card>
     <Button
       class="flex h-full min-h-md w-full items-center justify-center sm:min-h-full sm:min-w-lg"
-      :class="actionClass"
+      v-bind="button"
     >
       <span class="flex h-full w-full items-center justify-center">
         <slot name="action" />

--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -5,8 +5,8 @@ import Group from './Group.vue'
 import { defineComponent, type PropType } from 'vue'
 
 export const defaultProps = {
-  card: () => ({} as Record<string, unknown>),
-  button: () => ({} as Record<string, unknown>),
+  card: {} as Record<string, unknown>,
+  button: {} as Record<string, unknown>,
 } as const
 
 export type props = {
@@ -36,17 +36,17 @@ export default defineComponent({
 
 <template>
   <Group class="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto]">
-    <Card class="h-full" v-bind="card">
+    <Card class="h-full" v-bind="{ ...defaultProps.card, ...card }">
       <template v-for="(_, name) in $slots" :key="name" v-slot:[name]="data">
         <slot :name="name" v-bind="data" />
       </template>
     </Card>
     <Button
       class="flex h-full min-h-md w-full items-center justify-center sm:min-h-full sm:min-w-lg"
-      v-bind="button"
+      v-bind="{ ...defaultProps.button, ...button }"
     >
       <span class="flex h-full w-full items-center justify-center">
-        <slot name="action" />
+        <slot name="button" />
       </span>
     </Button>
   </Group>

--- a/playground/src/demos/ActionableCardDemo.vue
+++ b/playground/src/demos/ActionableCardDemo.vue
@@ -10,8 +10,8 @@ export const demoConfig: ComponentDemoConfig = {
       type: 'object',
       label: { en: 'Card Properties', ko: '카드 속성' },
       helperText: {
-        en: 'Props forwarded directly to the PrimeVue Card component.',
-        ko: 'PrimeVue Card 컴포넌트에 그대로 전달되는 속성입니다.',
+        en: 'Props forwarded to the PrimeVue Card component.',
+        ko: 'PrimeVue Card 컴포넌트에 전달되는 속성입니다.',
       },
     },
     {
@@ -19,8 +19,8 @@ export const demoConfig: ComponentDemoConfig = {
       type: 'object',
       label: { en: 'Button Properties', ko: '버튼 속성' },
       helperText: {
-        en: 'Props forwarded directly to the PrimeVue Button component.',
-        ko: 'PrimeVue Button 컴포넌트에 그대로 전달되는 속성입니다.',
+        en: 'Props forwarded to the PrimeVue Button component.',
+        ko: 'PrimeVue Button 컴포넌트에 전달되는 속성입니다.',
       },
     },
   ],

--- a/playground/src/demos/ActionableCardDemo.vue
+++ b/playground/src/demos/ActionableCardDemo.vue
@@ -6,21 +6,21 @@ export const demoConfig: ComponentDemoConfig = {
   defaultProps: actionableCardDefaults,
   properties: [
     {
-      key: 'cardClass',
-      type: 'text',
-      label: { en: 'Card classes', ko: '카드 클래스' },
+      key: 'card',
+      type: 'object',
+      label: { en: 'Card Properties', ko: '카드 속성' },
       helperText: {
-        en: 'Utility classes applied to the content area wrapper.',
-        ko: '콘텐츠 영역 래퍼에 적용할 Tailwind 클래스입니다.',
+        en: 'Props forwarded directly to the PrimeVue Card component.',
+        ko: 'PrimeVue Card 컴포넌트에 그대로 전달되는 속성입니다.',
       },
     },
     {
-      key: 'actionClass',
-      type: 'text',
-      label: { en: 'Action classes', ko: '액션 클래스' },
+      key: 'button',
+      type: 'object',
+      label: { en: 'Button Properties', ko: '버튼 속성' },
       helperText: {
-        en: 'Utility classes applied to the action slot wrapper.',
-        ko: '액션 슬롯 래퍼에 적용할 Tailwind 클래스입니다.',
+        en: 'Props forwarded directly to the PrimeVue Button component.',
+        ko: 'PrimeVue Button 컴포넌트에 그대로 전달되는 속성입니다.',
       },
     },
   ],


### PR DESCRIPTION
## Summary
- replace the ActionableCard `cardClass` and `actionClass` props with `card` and `button` configuration objects
- forward the new props to the underlying PrimeVue Card and Button components
- update the ActionableCard playground demo controls to edit the Card and Button property objects

## Testing
- `npx vue-tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68e687519758832cabd53f100fc8bd12