### PR TITLE
Fix ActionableCard default binding and adjust demo controls

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -21,6 +21,11 @@ export default defineComponent({
     Card,
     Group,
   },
+  setup() {
+    return {
+      defaultProps,
+    }
+  },
   props: {
     card: {
       type: Object as PropType<Record<string, unknown>>,

--- a/playground/src/demos/ActionableCardDemo.vue
+++ b/playground/src/demos/ActionableCardDemo.vue
@@ -7,7 +7,7 @@ export const demoConfig: ComponentDemoConfig = {
   properties: [
     {
       key: 'card',
-      type: 'object',
+      type: 'textarea',
       label: { en: 'Card Properties', ko: '카드 속성' },
       helperText: {
         en: 'Props forwarded to the PrimeVue Card component.',
@@ -16,7 +16,7 @@ export const demoConfig: ComponentDemoConfig = {
     },
     {
       key: 'button',
-      type: 'object',
+      type: 'textarea',
       label: { en: 'Button Properties', ko: '버튼 속성' },
       helperText: {
         en: 'Props forwarded to the PrimeVue Button component.',


### PR DESCRIPTION
## Summary
- expose the ActionableCard defaultProps in setup so the template can access them
- update the ActionableCard playground demo controls to use a supported textarea control type

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e68c1ea4d4832ca8f5e927b55bfe9a