### PR TITLE
Fix ActionableCard button icon display

### DIFF
--- a/library/components/ActionableCard.vue
+++ b/library/components/ActionableCard.vue
@@ -50,9 +50,11 @@ export default defineComponent({
       class="flex h-full min-h-md w-full items-center justify-center sm:min-h-full sm:min-w-lg"
       v-bind="{ ...defaultProps.button, ...button }"
     >
-      <span class="flex h-full w-full items-center justify-center">
-        <slot name="button" />
-      </span>
+      <template v-if="$slots.button">
+        <span class="flex h-full w-full items-center justify-center">
+          <slot name="button" />
+        </span>
+      </template>
     </Button>
   </Group>
 </template>


### PR DESCRIPTION
## Summary
- only render the ActionableCard button slot wrapper when custom button content is provided so PrimeVue can show icon-only buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e695436cd0832cbe28a8a24e2b9669