### PR TITLE
Replace w-full h-full classes with size-full

### DIFF
--- a/library/components/BlurOverlay.vue
+++ b/library/components/BlurOverlay.vue
@@ -53,7 +53,7 @@ export default defineComponent({
 
 <template>
   <transition name="fade-blur">
-    <div class="flex absolute inset-0 w-full h-full rounded-inherit" :style="overlayStyle">
+    <div class="flex absolute inset-0 size-full rounded-inherit" :style="overlayStyle">
       <slot />
     </div>
   </transition>

--- a/library/components/QrCode.vue
+++ b/library/components/QrCode.vue
@@ -77,9 +77,9 @@ export default defineComponent({
 
 <template>
   <section class="relative aspect-square bg-surface-0 p-4">
-    <div class="flex w-full h-full items-center justify-center">
+    <div class="flex size-full items-center justify-center">
       <ElText v-if="qrError" type="warning" tag="span" size="small">{{ qrError }}</ElText>
-      <img v-else :src="qrSource" alt="QR code" class="w-full h-full object-contain"
+      <img v-else :src="qrSource" alt="QR code" class="size-full object-contain"
         style="image-rendering: crisp-edges; image-rendering: pixelated;"
       />
     </div>

--- a/library/components/Spinner.vue
+++ b/library/components/Spinner.vue
@@ -55,8 +55,8 @@ export default defineComponent({
     :style="dimensions"
     aria-hidden="true"
   >
-    <div class="h-full w-full animate-spin rounded-full border-solid border-current" :style="ringStyle" />
-    <div class="absolute h-full w-full inset-0 flex items-center justify-center">
+    <div class="size-full animate-spin rounded-full border-solid border-current" :style="ringStyle" />
+    <div class="absolute size-full inset-0 flex items-center justify-center">
       <slot />
     </div>
   </div>

--- a/playground/src/demos/BlurOverlayDemo.vue
+++ b/playground/src/demos/BlurOverlayDemo.vue
@@ -44,7 +44,7 @@ defineProps<BlurOverlayProps>()
     <img
       src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1000&q=80"
       alt="Developer workspace"
-      class="absolute inset-0 w-full h-full object-cover"
+      class="absolute inset-0 size-full object-cover"
     />
     <BlurOverlay v-bind="$props">
       <div class="flex flex-col gap-4">

--- a/playground/src/demos/LoadingOverlayDemo.vue
+++ b/playground/src/demos/LoadingOverlayDemo.vue
@@ -81,7 +81,7 @@ defineProps<LoadingOverlayProps>()
     <img
       src="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1000&q=80"
       alt="Project dashboard"
-      class="absolute inset-0 w-full h-full object-cover"
+      class="absolute inset-0 size-full object-cover"
     />
     <LoadingOverlay v-bind="$props" />
   </div>


### PR DESCRIPTION
## Summary
- replace the combined `w-full`/`h-full` utility classes with the Tailwind `size-full` shorthand in shared components and demos
- ensure overlays and the spinner rely on the consolidated sizing utility for consistency

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e73a32b9e8832c86fda4d59a67afdd