### PR TITLE
Simplify OverlayContainer API

### DIFF
--- a/library/components/OverlayContainer.vue
+++ b/library/components/OverlayContainer.vue
@@ -3,18 +3,10 @@ import { defineComponent } from 'vue'
 
 export const defaultProps = {
   overlay: true,
-  blurStrength: 7,
-  backgroundColor: 'rgba(0, 0, 0, 0.25)',
-  centerVertical: true,
-  centerHorizontal: true,
 } as const
 
 export type props = {
   overlay?: boolean
-  blurStrength?: number
-  backgroundColor?: string
-  centerVertical?: boolean
-  centerHorizontal?: boolean
 }
 
 export default defineComponent({
@@ -24,35 +16,6 @@ export default defineComponent({
       type: Boolean,
       default: defaultProps.overlay,
     },
-    blurStrength: {
-      type: Number,
-      default: defaultProps.blurStrength,
-    },
-    backgroundColor: {
-      type: String,
-      default: defaultProps.backgroundColor,
-    },
-    centerVertical: {
-      type: Boolean,
-      default: defaultProps.centerVertical,
-    },
-    centerHorizontal: {
-      type: Boolean,
-      default: defaultProps.centerHorizontal,
-    },
-  },
-  computed: {
-    overlayStyle(): Record<string, string> {
-      const blur = `blur(${this.blurStrength}px)`
-
-      return {
-        backdropFilter: blur,
-        WebkitBackdropFilter: blur,
-        background: this.backgroundColor,
-        alignItems: this.centerVertical ? 'center' : 'flex-start',
-        justifyContent: this.centerHorizontal ? 'center' : 'flex-start',
-      }
-    },
   },
 })
 </script>
@@ -61,7 +24,7 @@ export default defineComponent({
   <div class="relative">
     <slot />
     <transition name="fade-blur">
-      <div v-if="overlay" class="flex absolute inset-0 size-full rounded-inherit" :style="overlayStyle">
+      <div v-if="overlay" class="absolute inset-0 size-full rounded-inherit">
         <slot name="overlay" />
       </div>
     </transition>

--- a/showcase/src/demos/OverlayContainerDemo.vue
+++ b/showcase/src/demos/OverlayContainerDemo.vue
@@ -10,29 +10,6 @@ export const demoConfig: ComponentDemoConfig = {
       type: 'boolean',
       label: { en: 'Enable Overlay', ko: '오버레이 사용' },
     },
-    {
-      key: 'blurStrength',
-      type: 'slider',
-      label: { en: 'Blur Strength', ko: '블러 강도' },
-      min: 0,
-      max: 30,
-      step: 1,
-    },
-    {
-      key: 'backgroundColor',
-      type: 'color',
-      label: { en: 'Background Color', ko: '배경 색상' },
-    },
-    {
-      key: 'centerVertical',
-      type: 'boolean',
-      label: { en: 'Center Vertically', ko: '세로 중앙 정렬' },
-    },
-    {
-      key: 'centerHorizontal',
-      type: 'boolean',
-      label: { en: 'Center Horizontally', ko: '가로 중앙 정렬' },
-    },
   ],
 }
 </script>
@@ -56,16 +33,20 @@ defineProps<OverlayContainerProps>()
       />
     </div>
     <template #overlay>
-      <div class="flex flex-col gap-4">
-        <ElText tag="span" class="font-semibold uppercase tracking-[0.4em]" size="small" type="primary">
-          Focus Mode
-        </ElText>
-        <ElText tag="h2" size="large" class="font-semibold">
-          Shipping polished experiences
-        </ElText>
-        <ElText tag="p" size="small">
-          Blur surrounding distractions while presenting a focused call-to-action for your customers.
-        </ElText>
+      <div
+        class="flex size-full items-center justify-center rounded-inherit bg-black/25 p-10 text-left text-white backdrop-blur-[7px]"
+      >
+        <div class="flex max-w-md flex-col gap-4">
+          <ElText tag="span" class="font-semibold uppercase tracking-[0.4em]" size="small" type="primary">
+            Focus Mode
+          </ElText>
+          <ElText tag="h2" size="large" class="font-semibold">
+            Shipping polished experiences
+          </ElText>
+          <ElText tag="p" size="small">
+            Blur surrounding distractions while presenting a focused call-to-action for your customers.
+          </ElText>
+        </div>
       </div>
     </template>
   </OverlayContainer>


### PR DESCRIPTION
## Summary
- remove styling-related props and computed styles from OverlayContainer so it only toggles the overlay slot
- update the showcase demo to recreate the overlay presentation directly within the slot content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e74b9626b0832ca1515f50f99d8b9e