### PR TITLE
Remove shadow from Group component children

### DIFF
--- a/library/components/Group.vue
+++ b/library/components/Group.vue
@@ -169,6 +169,7 @@ export default defineComponent({
 <style scoped>
 .group-root ::v-slotted(.group-item) {
   border-radius: 0 !important;
+  box-shadow: none !important;
 }
 
 .group-root ::v-slotted(.group-corner-top-left) {

--- a/library/components/Group.vue
+++ b/library/components/Group.vue
@@ -168,23 +168,23 @@ export default defineComponent({
 
 <style scoped>
 .group-root ::v-slotted(.group-item) {
-  border-radius: 0 !important;
-  box-shadow: none !important;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .group-root ::v-slotted(.group-corner-top-left) {
-  border-top-left-radius: inherit !important;
+  border-top-left-radius: inherit;
 }
 
 .group-root ::v-slotted(.group-corner-top-right) {
-  border-top-right-radius: inherit !important;
+  border-top-right-radius: inherit;
 }
 
 .group-root ::v-slotted(.group-corner-bottom-left) {
-  border-bottom-left-radius: inherit !important;
+  border-bottom-left-radius: inherit;
 }
 
 .group-root ::v-slotted(.group-corner-bottom-right) {
-  border-bottom-right-radius: inherit !important;
+  border-bottom-right-radius: inherit;
 }
 </style>


### PR DESCRIPTION
## Summary
- ensure Group component slotted children have no box shadow applied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e74e034134832cb8b73232d8e8ff36