### PR TITLE
Allow scoped dark mode using class selector

### DIFF
--- a/library/styles/base.css
+++ b/library/styles/base.css
@@ -7,10 +7,14 @@
     color-scheme: light;
     @apply font-sans bg-surface-50;
   }
-  
+
   :root.dark {
     color-scheme: dark;
     @apply font-sans bg-surface-950;
+  }
+
+  .dark {
+    color-scheme: dark;
   }
 
   body {

--- a/library/styles/element-plus.css
+++ b/library/styles/element-plus.css
@@ -17,7 +17,8 @@
   --el-font-family: var(--p-font-family, 'Noto Sans KR', Inter, ui-sans-serif, system-ui);
 }
 
-:root.dark {
+:root.dark,
+.dark {
   --el-color-primary: var(--p-primary-400);
   --el-color-primary-light-3: color-mix(in srgb, var(--p-primary-400) 65%, white 35%);
   --el-color-primary-light-5: color-mix(in srgb, var(--p-primary-400) 50%, white 50%);


### PR DESCRIPTION
## Summary
- allow the `.dark` class to set the dark color scheme without requiring it on `:root`
- update Element Plus CSS variables so components inside a `.dark` container use dark values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e755bf21d4832c9f93ac832097c5fa