### PR TITLE
Add backdrop filter prop to overlay container

### DIFF
--- a/library/components/OverlayContainer.vue
+++ b/library/components/OverlayContainer.vue
@@ -3,10 +3,12 @@ import { defineComponent } from 'vue'
 
 export const defaultProps = {
   overlay: true,
+  backdropFilter: 'blur(7px)',
 } as const
 
 export type props = {
   overlay?: boolean
+  backdropFilter?: string
 }
 
 export default defineComponent({
@@ -16,6 +18,10 @@ export default defineComponent({
       type: Boolean,
       default: defaultProps.overlay,
     },
+    backdropFilter: {
+      type: String,
+      default: defaultProps.backdropFilter,
+    },
   },
 })
 </script>
@@ -24,7 +30,11 @@ export default defineComponent({
   <div class="relative">
     <slot />
     <transition name="fade">
-      <div v-if="overlay" class="absolute inset-0 size-full rounded-inherit backdrop-blur-[7px]">
+      <div
+        v-if="overlay"
+        class="absolute inset-0 size-full rounded-inherit"
+        :style="{ backdropFilter }"
+      >
         <slot name="overlay" />
       </div>
     </transition>

--- a/showcase/src/demos/OverlayContainerDemo.vue
+++ b/showcase/src/demos/OverlayContainerDemo.vue
@@ -10,6 +10,15 @@ export const demoConfig: ComponentDemoConfig = {
       type: 'boolean',
       label: { en: 'Enable Overlay', ko: '오버레이 사용' },
     },
+    {
+      key: 'backdropFilter',
+      type: 'text',
+      label: { en: 'Backdrop Filter', ko: '백드롭 필터' },
+      helperText: {
+        en: 'CSS backdrop-filter value applied to the overlay layer.',
+        ko: '오버레이 레이어에 적용되는 CSS backdrop-filter 값입니다.',
+      },
+    },
   ],
 }
 </script>


### PR DESCRIPTION
## Summary
- add a configurable `backdropFilter` prop to `OverlayContainer` with a default blur value
- surface the new property in the demo controls so the CSS filter can be edited

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e76948d760832c970434cc443b37c5