### PR TITLE
Add LiquidGlass wrapper component

### DIFF
--- a/library/components/LiquidGlass.vue
+++ b/library/components/LiquidGlass.vue
@@ -1,0 +1,19 @@
+<script lang="ts">
+export const defaultProps = {} as Record<string, unknown>
+
+export type props = Record<string, never>
+</script>
+
+<script setup lang="ts">
+import { LiquidGlass as LiquidGlassBase } from 'liquid-glass-vue'
+
+defineOptions({
+  name: 'LiquidGlass',
+})
+</script>
+
+<template>
+  <LiquidGlassBase v-bind="$attrs">
+    <slot />
+  </LiquidGlassBase>
+</template>

--- a/library/components/index.ts
+++ b/library/components/index.ts
@@ -3,3 +3,4 @@ export { default as OverlayContainer, type props as OverlayContainerProps } from
 export { default as Group, type props as GroupProps } from './Group.vue'
 export { default as QrCode, type props as QrCodeProps } from './QrCode.vue'
 export { default as Spinner, type props as SpinnerProps } from './Spinner.vue'
+export { default as LiquidGlass, type props as LiquidGlassProps } from './LiquidGlass.vue'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@element-plus/icons-vue": "^2.3.2",
         "@primevue/themes": "^4.4.0",
         "element-plus": "^2.11.4",
+        "liquid-glass-vue": "^0.0.1",
         "primeicons": "^7.0.0",
         "primevue": "^4.4.0",
         "qrcode": "^1.5.4",
@@ -2362,6 +2363,12 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/liquid-glass-vue": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/liquid-glass-vue/-/liquid-glass-vue-0.0.1.tgz",
+      "integrity": "sha512-zmzMq2rKeMr+QITTH3h00TrAhUJUh2bmDeXLIR49c2QkrkCDN2A1zuZMYmSXN3ioR2+5QNd8a6djwnOTZH/ccg==",
       "license": "MIT"
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@element-plus/icons-vue": "^2.3.2",
     "@primevue/themes": "^4.4.0",
     "element-plus": "^2.11.4",
+    "liquid-glass-vue": "^0.0.1",
     "primeicons": "^7.0.0",
     "primevue": "^4.4.0",
     "qrcode": "^1.5.4",

--- a/showcase/src/demos/LiquidGlassDemo.vue
+++ b/showcase/src/demos/LiquidGlassDemo.vue
@@ -1,0 +1,24 @@
+<script lang="ts">
+import { defaultProps as liquidGlassDefaults } from '@library/components/LiquidGlass.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: liquidGlassDefaults,
+  properties: [],
+}
+</script>
+
+<script setup lang="ts">
+import { LiquidGlass, type LiquidGlassProps } from '@library/components'
+
+defineProps<LiquidGlassProps>()
+</script>
+
+<template>
+  <LiquidGlass v-bind="$props">
+    <div class="space-y-2 rounded-xl bg-white/10 p-6 text-white">
+      <h2 class="text-lg font-semibold">Your content here</h2>
+      <p class="text-sm text-white/80">This will have the liquid glass effect</p>
+    </div>
+  </LiquidGlass>
+</template>

--- a/showcase/src/demos/index.ts
+++ b/showcase/src/demos/index.ts
@@ -1,5 +1,6 @@
 import ActionableCardDemo, { demoConfig as actionableCardConfig } from './ActionableCardDemo.vue'
 import OverlayContainerDemo, { demoConfig as overlayContainerConfig } from './OverlayContainerDemo.vue'
+import LiquidGlassDemo, { demoConfig as liquidGlassConfig } from './LiquidGlassDemo.vue'
 import GroupDemo, { demoConfig as groupConfig } from './GroupDemo.vue'
 import QrCodeDemo, { demoConfig as qrCodeConfig } from './QrCodeDemo.vue'
 import SpinnerDemo, { demoConfig as spinnerConfig } from './SpinnerDemo.vue'
@@ -17,6 +18,10 @@ const demoEntries: Record<string, ComponentDemo> = {
   'overlay-container': {
     component: OverlayContainerDemo,
     ...overlayContainerConfig,
+  },
+  'liquid-glass': {
+    component: LiquidGlassDemo,
+    ...liquidGlassConfig,
   },
   'qr-code': {
     component: QrCodeDemo,

--- a/showcase/src/library/catalog.ts
+++ b/showcase/src/library/catalog.ts
@@ -62,6 +62,17 @@ export const componentCatalog: LabComponentSummary[] = [
       ko: '필요에 따라 블러 오버레이를 더해 콘텐츠를 겹쳐 배치합니다.',
     },
   },
+  {
+    id: 'liquid-glass',
+    name: {
+      en: 'Liquid Glass',
+      ko: '리퀴드 글래스',
+    },
+    description: {
+      en: 'Wrap surfaces with a glossy, glass-like effect for modern layouts.',
+      ko: '현대적인 레이아웃을 위해 표면에 유리 같은 광택 효과를 씌웁니다.',
+    },
+  },
 ]
 
 export const componentMap = new Map(componentCatalog.map((item) => [item.id, item]))


### PR DESCRIPTION
## Summary
- add the liquid-glass-vue dependency
- add a LiquidGlass wrapper component in the library with exported default props
- export the new component from the library entrypoint
- add a LiquidGlass showcase demo using the default props

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e76b4b4894832cbe237b0a150327c1