### PR TITLE
Add LiquidGlass defaults and showcase demo

### DIFF
--- a/library/components/LiquidGlass.vue
+++ b/library/components/LiquidGlass.vue
@@ -1,0 +1,21 @@
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { LiquidGlass as LiquidGlassBase } from 'liquid-glass-vue'
+
+export const defaultProps = {} as Record<string, unknown>
+
+export type props = {}
+
+export default defineComponent({
+  name: 'LiquidGlass',
+  components: {
+    LiquidGlassBase,
+  },
+})
+</script>
+
+<template>
+  <LiquidGlassBase v-bind="$attrs">
+    <slot />
+  </LiquidGlassBase>
+</template>

--- a/library/components/index.ts
+++ b/library/components/index.ts
@@ -3,3 +3,4 @@ export { default as OverlayContainer, type props as OverlayContainerProps } from
 export { default as Group, type props as GroupProps } from './Group.vue'
 export { default as QrCode, type props as QrCodeProps } from './QrCode.vue'
 export { default as Spinner, type props as SpinnerProps } from './Spinner.vue'
+export { default as LiquidGlass, type props as LiquidGlassProps } from './LiquidGlass.vue'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@element-plus/icons-vue": "^2.3.2",
         "@primevue/themes": "^4.4.0",
         "element-plus": "^2.11.4",
+        "liquid-glass-vue": "^0.0.1",
         "primeicons": "^7.0.0",
         "primevue": "^4.4.0",
         "qrcode": "^1.5.4",
@@ -2362,6 +2363,12 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/liquid-glass-vue": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/liquid-glass-vue/-/liquid-glass-vue-0.0.1.tgz",
+      "integrity": "sha512-zmzMq2rKeMr+QITTH3h00TrAhUJUh2bmDeXLIR49c2QkrkCDN2A1zuZMYmSXN3ioR2+5QNd8a6djwnOTZH/ccg==",
       "license": "MIT"
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@element-plus/icons-vue": "^2.3.2",
     "@primevue/themes": "^4.4.0",
     "element-plus": "^2.11.4",
+    "liquid-glass-vue": "^0.0.1",
     "primeicons": "^7.0.0",
     "primevue": "^4.4.0",
     "qrcode": "^1.5.4",

--- a/showcase/src/demos/LiquidGlassDemo.vue
+++ b/showcase/src/demos/LiquidGlassDemo.vue
@@ -1,0 +1,36 @@
+<script lang="ts">
+import { defaultProps as liquidGlassDefaults } from '@library/components/LiquidGlass.vue'
+import type { ComponentDemoConfig } from '@/demos/types'
+
+export const demoConfig: ComponentDemoConfig = {
+  defaultProps: liquidGlassDefaults,
+  properties: [],
+}
+</script>
+
+<script setup lang="ts">
+import { LiquidGlass } from '@library/components'
+</script>
+
+<template>
+  <div
+    class="relative flex min-h-[280px] items-center justify-center overflow-hidden rounded-3xl bg-gradient-to-br from-surface-900 via-indigo-900 to-black p-10"
+  >
+    <div class="pointer-events-none absolute -left-12 top-10 size-72 rounded-full bg-cyan-400/40 blur-3xl" />
+    <div class="pointer-events-none absolute -bottom-16 right-0 size-64 rounded-full bg-purple-500/40 blur-3xl" />
+    <LiquidGlass class="relative w-full max-w-md rounded-3xl border border-white/25 bg-white/10 p-6 text-white shadow-2xl">
+      <div class="flex flex-col gap-3">
+        <h2 class="text-2xl font-semibold tracking-wide">Liquid glass surface</h2>
+        <p class="text-sm text-white/80">
+          Layer your content on top of vibrant imagery while keeping it legible and tactile.
+        </p>
+        <button
+          type="button"
+          class="self-start rounded-full bg-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/30"
+        >
+          Explore now
+        </button>
+      </div>
+    </LiquidGlass>
+  </div>
+</template>

--- a/showcase/src/demos/index.ts
+++ b/showcase/src/demos/index.ts
@@ -1,5 +1,6 @@
 import ActionableCardDemo, { demoConfig as actionableCardConfig } from './ActionableCardDemo.vue'
 import OverlayContainerDemo, { demoConfig as overlayContainerConfig } from './OverlayContainerDemo.vue'
+import LiquidGlassDemo, { demoConfig as liquidGlassConfig } from './LiquidGlassDemo.vue'
 import GroupDemo, { demoConfig as groupConfig } from './GroupDemo.vue'
 import QrCodeDemo, { demoConfig as qrCodeConfig } from './QrCodeDemo.vue'
 import SpinnerDemo, { demoConfig as spinnerConfig } from './SpinnerDemo.vue'
@@ -17,6 +18,10 @@ const demoEntries: Record<string, ComponentDemo> = {
   'overlay-container': {
     component: OverlayContainerDemo,
     ...overlayContainerConfig,
+  },
+  'liquid-glass': {
+    component: LiquidGlassDemo,
+    ...liquidGlassConfig,
   },
   'qr-code': {
     component: QrCodeDemo,

--- a/showcase/src/library/catalog.ts
+++ b/showcase/src/library/catalog.ts
@@ -52,6 +52,17 @@ export const componentCatalog: LabComponentSummary[] = [
     },
   },
   {
+    id: 'liquid-glass',
+    name: {
+      en: 'Liquid Glass',
+      ko: '리퀴드 글래스',
+    },
+    description: {
+      en: 'Apply a tactile frosted glass effect to highlight layered content.',
+      ko: '겹쳐진 콘텐츠를 돋보이게 하는 서리 낀 유리 효과를 제공합니다.',
+    },
+  },
+  {
     id: 'overlay-container',
     name: {
       en: 'Overlay Container',


### PR DESCRIPTION
## Summary
- export the LiquidGlass wrapper defaults and props from the component library
- add a LiquidGlass demo configuration and example surface in the showcase
- register the LiquidGlass component in the catalog for discovery

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e76b4b4894832cbe237b0a150327c1